### PR TITLE
create caleg api

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ Model/Entity yang sudah disiapkan:
 - Kode yang rapi dan mudah dimengerti
 - Nilai tambah jika ditambahkan unit test
 
+
+### [Swagger UI](http://127.0.0.1:8080/swagger-ui/index.html)
+

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,81 @@
 			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>jakarta.persistence</groupId>
+			<artifactId>jakarta.persistence-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>6.2.13.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.6.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator-core</artifactId>
+			<version>0.52</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.8.0</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/allobank/allobackendtest/AlloBackendTestApplication.java
+++ b/src/main/java/com/allobank/allobackendtest/AlloBackendTestApplication.java
@@ -2,8 +2,10 @@ package com.allobank.allobackendtest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class AlloBackendTestApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/allobank/allobackendtest/configuration/CacheConfig.java
+++ b/src/main/java/com/allobank/allobackendtest/configuration/CacheConfig.java
@@ -1,0 +1,61 @@
+package com.allobank.allobackendtest.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class CacheConfig implements CachingConfigurer {
+
+    @Value("${spring.cache.redis.time-to-live:3600000}")
+    private long timeToLive;
+
+    @Bean
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory, ObjectMapper redisObjectMapper) {
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(createCacheConfiguration(Duration.ofMillis(timeToLive)))
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+
+    private RedisCacheConfiguration createCacheConfiguration(Duration ttl) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(ttl)
+                .disableCachingNullValues()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+                );
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new RedisCacheErrorHandler();
+    }
+}

--- a/src/main/java/com/allobank/allobackendtest/configuration/RedisCacheErrorHandler.java
+++ b/src/main/java/com/allobank/allobackendtest/configuration/RedisCacheErrorHandler.java
@@ -1,0 +1,32 @@
+package com.allobank.allobackendtest.configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+
+
+public class RedisCacheErrorHandler implements CacheErrorHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(RedisCacheErrorHandler.class);
+
+    @Override
+    public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        logger.error("Error getting from cache: {} with key: {}", cache.getName(), key, exception);
+    }
+
+    @Override
+    public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+        logger.error("Error putting into cache: {} with key: {}", cache.getName(), key, exception);
+    }
+
+    @Override
+    public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        logger.error("Error evicting from cache: {} with key: {}", cache.getName(), key, exception);
+    }
+
+    @Override
+    public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        logger.error("Error clearing cache: {}", cache.getName(), exception);
+    }
+}

--- a/src/main/java/com/allobank/allobackendtest/configuration/RedisConfig.java
+++ b/src/main/java/com/allobank/allobackendtest/configuration/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.allobank.allobackendtest.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.redis.port:6379}")
+    private int redisPort;
+
+    @Autowired
+    private ObjectMapper redisObjectMapper;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper));
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper));
+        template.setEnableTransactionSupport(true);
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/allobank/allobackendtest/controller/CalegController.java
+++ b/src/main/java/com/allobank/allobackendtest/controller/CalegController.java
@@ -1,0 +1,40 @@
+package com.allobank.allobackendtest.controller;
+
+import com.allobank.allobackendtest.dto.CalegDTO;
+import com.allobank.allobackendtest.dto.DetailCalegDTO;
+import com.allobank.allobackendtest.dto.PaginatedResponseDTO;
+import com.allobank.allobackendtest.service.CalegService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/caleg")
+@RequiredArgsConstructor
+public class CalegController implements ICalegController{
+
+    private final CalegService calegService;
+
+    @GetMapping
+    public ResponseEntity<PaginatedResponseDTO<CalegDTO>> getAllCaleg(
+            @RequestParam(required = false) UUID dapilId,
+            @RequestParam(required = false) UUID partaiId,
+            @RequestParam(required = false, defaultValue = "ASC") Sort.Direction sortDirection,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        Sort sort = Sort.by(sortDirection, "nomorUrut");
+        PaginatedResponseDTO<CalegDTO> calegList = calegService.getAllCaleg(dapilId, partaiId, sort, page);
+        return ResponseEntity.ok(calegList);
+    }
+
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DetailCalegDTO> getCalegById(@PathVariable UUID id) {
+        DetailCalegDTO caleg = calegService.getCalegById(id);
+        return ResponseEntity.ok(caleg);
+    }
+}

--- a/src/main/java/com/allobank/allobackendtest/controller/ICalegController.java
+++ b/src/main/java/com/allobank/allobackendtest/controller/ICalegController.java
@@ -1,0 +1,23 @@
+package com.allobank.allobackendtest.controller;
+
+import com.allobank.allobackendtest.dto.CalegDTO;
+import com.allobank.allobackendtest.dto.DetailCalegDTO;
+import com.allobank.allobackendtest.dto.PaginatedResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ICalegController {
+    ResponseEntity<PaginatedResponseDTO<CalegDTO>> getAllCaleg(
+            @RequestParam(required = false) UUID dapilId,
+            @RequestParam(required = false) UUID partaiId,
+            @RequestParam(required = false, defaultValue = "ASC") Sort.Direction sortDirection,
+            @RequestParam(defaultValue = "0") int page
+    );
+
+    ResponseEntity<DetailCalegDTO> getCalegById(@PathVariable UUID id);
+}

--- a/src/main/java/com/allobank/allobackendtest/dto/CalegDTO.java
+++ b/src/main/java/com/allobank/allobackendtest/dto/CalegDTO.java
@@ -1,0 +1,25 @@
+package com.allobank.allobackendtest.dto;
+
+import com.allobank.allobackendtest.model.JenisKelamin;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalegDTO implements Serializable {
+    private UUID id;
+    private Integer nomorUrut;
+    private String nama;
+    private JenisKelamin jenisKelamin;
+
+    private DapilDTO dapil;
+
+    private PartaiDTO partai;
+}

--- a/src/main/java/com/allobank/allobackendtest/dto/DapilDTO.java
+++ b/src/main/java/com/allobank/allobackendtest/dto/DapilDTO.java
@@ -1,0 +1,20 @@
+package com.allobank.allobackendtest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DapilDTO implements Serializable {
+    private UUID id;
+    private String nama;
+    private String provinsi;
+}

--- a/src/main/java/com/allobank/allobackendtest/dto/DetailCalegDTO.java
+++ b/src/main/java/com/allobank/allobackendtest/dto/DetailCalegDTO.java
@@ -1,0 +1,25 @@
+package com.allobank.allobackendtest.dto;
+
+import com.allobank.allobackendtest.model.JenisKelamin;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DetailCalegDTO implements Serializable {
+    private UUID id;
+    private Integer nomorUrut;
+    private String nama;
+    private JenisKelamin jenisKelamin;
+
+    private DetailDapilDTO dapil;
+
+    private PartaiDTO partai;
+}

--- a/src/main/java/com/allobank/allobackendtest/dto/DetailDapilDTO.java
+++ b/src/main/java/com/allobank/allobackendtest/dto/DetailDapilDTO.java
@@ -1,0 +1,22 @@
+package com.allobank.allobackendtest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DetailDapilDTO implements Serializable {
+    private UUID id;
+    private String nama;
+    private String provinsi;
+    private List<String> wilayah;
+    private int jumlahKursi;
+}

--- a/src/main/java/com/allobank/allobackendtest/dto/PaginatedResponseDTO.java
+++ b/src/main/java/com/allobank/allobackendtest/dto/PaginatedResponseDTO.java
@@ -1,0 +1,18 @@
+package com.allobank.allobackendtest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaginatedResponseDTO<T> {
+    private List<T> data;
+    private long totalItems;
+    private int totalPages;
+}

--- a/src/main/java/com/allobank/allobackendtest/dto/PartaiDTO.java
+++ b/src/main/java/com/allobank/allobackendtest/dto/PartaiDTO.java
@@ -1,0 +1,20 @@
+package com.allobank.allobackendtest.dto;
+
+import com.allobank.allobackendtest.model.JenisKelamin;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartaiDTO implements Serializable{
+    private UUID id;
+    private String nama;
+    private Integer nomorUrut;
+}

--- a/src/main/java/com/allobank/allobackendtest/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/allobank/allobackendtest/exception/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.allobank.allobackendtest.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.LocalDateTime;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Internal Server Error",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFoundException(ResourceNotFoundException ex, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage(),
+                LocalDateTime.now()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler({ MethodArgumentTypeMismatchException.class })
+    public ResponseEntity<String> handleEnumBindingException(MethodArgumentTypeMismatchException ex) {
+        if (ex.getRequiredType() == Sort.Direction.class) {
+            return ResponseEntity.badRequest().body("Invalid sort direction. Use ASC or DESC.");
+        }
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ErrorResponse {
+        private int status;
+        private String error;
+        private String message;
+        private LocalDateTime timestamp;
+    }
+}

--- a/src/main/java/com/allobank/allobackendtest/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/allobank/allobackendtest/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.allobank.allobackendtest.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+    }
+}

--- a/src/main/java/com/allobank/allobackendtest/model/Caleg.java
+++ b/src/main/java/com/allobank/allobackendtest/model/Caleg.java
@@ -1,15 +1,30 @@
 package com.allobank.allobackendtest.model;
 
 import lombok.Data;
-
+import jakarta.persistence.*;
 import java.util.UUID;
 
 @Data
+@Entity
+@Table(name = "caleg")
 public class Caleg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "dapil_id")
     private Dapil dapil;
+
+    @ManyToOne
+    @JoinColumn(name = "partai_id")
     private Partai partai;
+
     private Integer nomorUrut;
+
     private String nama;
+
+    @Enumerated(EnumType.STRING)
     private JenisKelamin jenisKelamin;
 }

--- a/src/main/java/com/allobank/allobackendtest/model/Dapil.java
+++ b/src/main/java/com/allobank/allobackendtest/model/Dapil.java
@@ -1,15 +1,27 @@
 package com.allobank.allobackendtest.model;
 
 import lombok.Data;
-
+import jakarta.persistence.*;
 import java.util.List;
 import java.util.UUID;
 
 @Data
+@Entity
+@Table(name = "dapil")
 public class Dapil {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
+
     private String namaDapil;
+
     private String provinsi;
+
+    @ElementCollection
+    @CollectionTable(name = "dapil_wilayah", joinColumns = @JoinColumn(name = "dapil_id"))
+    @Column(name = "wilayah")
     private List<String> wilayahDapilList;
+
     private int jumlahKursi;
 }

--- a/src/main/java/com/allobank/allobackendtest/model/Partai.java
+++ b/src/main/java/com/allobank/allobackendtest/model/Partai.java
@@ -1,12 +1,19 @@
 package com.allobank.allobackendtest.model;
 
 import lombok.Data;
-
+import jakarta.persistence.*;
 import java.util.UUID;
 
 @Data
+@Entity
+@Table(name = "partai")
 public class Partai {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
+
     private String namaPartai;
+
     private Integer nomorUrut;
 }

--- a/src/main/java/com/allobank/allobackendtest/repository/CalegRepository.java
+++ b/src/main/java/com/allobank/allobackendtest/repository/CalegRepository.java
@@ -1,0 +1,15 @@
+package com.allobank.allobackendtest.repository;
+
+import com.allobank.allobackendtest.model.Caleg;
+import com.allobank.allobackendtest.model.Dapil;
+import com.allobank.allobackendtest.model.Partai;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface CalegRepository extends JpaRepository<Caleg, UUID>, JpaSpecificationExecutor<Caleg> {
+}

--- a/src/main/java/com/allobank/allobackendtest/service/CalegService.java
+++ b/src/main/java/com/allobank/allobackendtest/service/CalegService.java
@@ -1,0 +1,124 @@
+package com.allobank.allobackendtest.service;
+
+import com.allobank.allobackendtest.dto.CalegDTO;
+import com.allobank.allobackendtest.dto.DapilDTO;
+import com.allobank.allobackendtest.dto.PartaiDTO;
+import com.allobank.allobackendtest.dto.DetailCalegDTO;
+import com.allobank.allobackendtest.dto.DetailDapilDTO;
+import com.allobank.allobackendtest.dto.PaginatedResponseDTO;
+import com.allobank.allobackendtest.exception.ResourceNotFoundException;
+import com.allobank.allobackendtest.model.Caleg;
+import com.allobank.allobackendtest.repository.CalegRepository;
+import com.allobank.allobackendtest.specification.CalegSpecification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+
+
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CalegService implements ICalegService {
+
+    private final CalegRepository calegRepository;
+
+    @Override
+    @Cacheable(
+            value = "calegList",
+            key = "#root.methodName + '_' + #dapilId + '_' + #partaiId + '_' + #sort.toString() + '_' + #page",
+            unless = "#result == null"
+    )
+    public PaginatedResponseDTO<CalegDTO> getAllCaleg(UUID dapilId, UUID partaiId, Sort sort, int page) {
+        Specification<Caleg> spec = Specification.where(null);
+
+        if (dapilId != null) {
+            spec = spec.and(CalegSpecification.hasDapilId(dapilId));
+        }
+
+        if (partaiId != null) {
+            spec = spec.and(CalegSpecification.hasPartaiId(partaiId));
+        }
+
+        if (sort == null) {
+            sort = Sort.by(Sort.Direction.ASC, "nomorUrut");
+        }
+
+        Pageable pageable = PageRequest.of(page, 25, sort);
+        var calegPage = calegRepository.findAll(spec, pageable);
+
+        List<CalegDTO> content = calegPage.getContent().stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+
+        return PaginatedResponseDTO.<CalegDTO>builder()
+                .data(content)
+                .totalItems(calegPage.getTotalElements())
+                .totalPages(calegPage.getTotalPages())
+                .build();
+    }
+
+
+
+    @Cacheable(value = "caleg", key = "#root.methodName + '_' + #id.toString()", unless = "#result == null")
+    public DetailCalegDTO getCalegById(UUID id) {
+        return calegRepository.findById(id)
+                .map(this::convertToDetailDTO)
+                .orElseThrow(() -> new ResourceNotFoundException("Caleg not found with id: " + id));
+    }
+
+    private CalegDTO convertToDTO(Caleg caleg) {
+        return CalegDTO.builder()
+                .id(caleg.getId())
+                .nomorUrut(caleg.getNomorUrut())
+                .nama(caleg.getNama())
+                .jenisKelamin(caleg.getJenisKelamin())
+                .dapil(
+                        DapilDTO.builder()
+                                .id(caleg.getDapil().getId())
+                                .nama(caleg.getDapil().getNamaDapil())
+                                .provinsi(caleg.getDapil().getProvinsi())
+                                .build()
+                )
+                .partai(
+                        PartaiDTO.builder()
+                            .id(caleg.getPartai().getId())
+                            .nama(caleg.getPartai().getNamaPartai())
+                            .nomorUrut(caleg.getPartai().getNomorUrut())
+                            .build()
+                )
+                .build();
+    }
+    private DetailCalegDTO convertToDetailDTO(Caleg caleg) {
+        return DetailCalegDTO.builder()
+                .id(caleg.getId())
+                .nomorUrut(caleg.getNomorUrut())
+                .nama(caleg.getNama())
+                .jenisKelamin(caleg.getJenisKelamin())
+                .dapil(
+                        DetailDapilDTO.builder()
+                                .id(caleg.getDapil().getId())
+                                .nama(caleg.getDapil().getNamaDapil())
+                                .provinsi(caleg.getDapil().getProvinsi())
+                                .wilayah(caleg.getDapil().getWilayahDapilList())
+                                .jumlahKursi(caleg.getDapil().getJumlahKursi())
+                                .build()
+                )
+                .partai(
+                        PartaiDTO.builder()
+                                .id(caleg.getPartai().getId())
+                                .nama(caleg.getPartai().getNamaPartai())
+                                .nomorUrut(caleg.getPartai().getNomorUrut())
+                                .build()
+                )
+                .build();
+    }
+
+}

--- a/src/main/java/com/allobank/allobackendtest/service/ICalegService.java
+++ b/src/main/java/com/allobank/allobackendtest/service/ICalegService.java
@@ -1,0 +1,13 @@
+package com.allobank.allobackendtest.service;
+
+import com.allobank.allobackendtest.dto.CalegDTO;
+import com.allobank.allobackendtest.dto.DetailCalegDTO;
+import com.allobank.allobackendtest.dto.PaginatedResponseDTO;
+import org.springframework.data.domain.Sort;
+
+import java.util.UUID;
+
+public interface ICalegService {
+    PaginatedResponseDTO<CalegDTO> getAllCaleg(UUID dapilId, UUID partaiId, Sort sort, int page);
+    DetailCalegDTO getCalegById(UUID id);
+}

--- a/src/main/java/com/allobank/allobackendtest/specification/CalegSpecification.java
+++ b/src/main/java/com/allobank/allobackendtest/specification/CalegSpecification.java
@@ -1,0 +1,27 @@
+package com.allobank.allobackendtest.specification;
+
+import com.allobank.allobackendtest.model.Caleg;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.UUID;
+
+public class CalegSpecification {
+
+    public static Specification<Caleg> hasDapilId(UUID dapilId) {
+        return (root, query, criteriaBuilder) -> {
+            if (dapilId == null) {
+                return null;
+            }
+            return criteriaBuilder.equal(root.get("dapil").get("id"), dapilId);
+        };
+    }
+
+    public static Specification<Caleg> hasPartaiId(UUID partaiId) {
+        return (root, query, criteriaBuilder) -> {
+            if (partaiId == null) {
+                return null;
+            }
+            return criteriaBuilder.equal(root.get("partai").get("id"), partaiId);
+        };
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,25 @@
+spring.datasource.url=
+spring.datasource.username=
+spring.datasource.password=
 
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+logging.level.root=INFO
+logging.level.com.allobank=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+springdoc.api-docs.path=/api-docs
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.cache.type=redis
+spring.cache.redis.time-to-live=3600000
+spring.cache.redis.cache-null-values=false

--- a/src/main/resources/db/migration/V1__initial_migration.sql
+++ b/src/main/resources/db/migration/V1__initial_migration.sql
@@ -1,0 +1,33 @@
+CREATE TYPE jenis_kelamin AS ENUM ('LAKI_LAKI', 'PEREMPUAN');
+
+CREATE TABLE dapil (
+   id UUID PRIMARY KEY,
+   nama_dapil VARCHAR(255) NOT NULL,
+   provinsi VARCHAR(255) NOT NULL,
+   jumlah_kursi INTEGER NOT NULL
+);
+
+CREATE TABLE dapil_wilayah (
+   dapil_id UUID NOT NULL,
+   wilayah VARCHAR(255) NOT NULL,
+   PRIMARY KEY (dapil_id, wilayah),
+   FOREIGN KEY (dapil_id) REFERENCES dapil (id) ON DELETE CASCADE
+);
+
+CREATE TABLE partai (
+    id UUID PRIMARY KEY,
+    nama_partai VARCHAR(255) NOT NULL,
+    nomor_urut INTEGER NOT NULL UNIQUE
+);
+
+CREATE TABLE caleg (
+   id UUID PRIMARY KEY,
+   dapil_id UUID NOT NULL,
+   partai_id UUID NOT NULL,
+   nomor_urut INTEGER NOT NULL,
+   nama VARCHAR(255) NOT NULL,
+   jenis_kelamin jenis_kelamin NOT NULL,
+   FOREIGN KEY (dapil_id) REFERENCES dapil (id),
+   FOREIGN KEY (partai_id) REFERENCES partai (id),
+   UNIQUE (dapil_id, partai_id, nomor_urut)
+);

--- a/src/test/java/com/allobank/allobackendtest/controller/CalegControllerTest.java
+++ b/src/test/java/com/allobank/allobackendtest/controller/CalegControllerTest.java
@@ -1,0 +1,108 @@
+package com.allobank.allobackendtest.controller;
+
+import com.allobank.allobackendtest.dto.CalegDTO;
+import com.allobank.allobackendtest.dto.DetailCalegDTO;
+import com.allobank.allobackendtest.dto.PaginatedResponseDTO;
+import com.allobank.allobackendtest.service.CalegService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+class CalegControllerTest {
+
+    @Mock
+    private CalegService calegService;
+
+    @InjectMocks
+    private CalegController calegController;
+
+    private UUID dummyId;
+
+    @BeforeEach
+    void setUp() {
+        openMocks(this);
+        dummyId = UUID.randomUUID();
+    }
+
+    @Test
+    void testGetAllCaleg_success() {
+        PaginatedResponseDTO<CalegDTO> responseDTO = new PaginatedResponseDTO<>();
+        responseDTO.setData(Collections.emptyList());
+        responseDTO.setTotalItems(0);
+        responseDTO.setTotalPages(0);
+        responseDTO.setTotalItems(0);
+
+        when(calegService.getAllCaleg(null, null, Sort.by(Sort.Direction.ASC, "nomorUrut"), 0))
+                .thenReturn(responseDTO);
+
+        ResponseEntity<PaginatedResponseDTO<CalegDTO>> response = calegController.getAllCaleg(
+                null, null, Sort.Direction.ASC, 0);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(responseDTO, response.getBody());
+        verify(calegService).getAllCaleg(null, null, Sort.by(Sort.Direction.ASC, "nomorUrut"), 0);
+    }
+
+    @Test
+    void testGetAllCaleg_failure() {
+        when(calegService.getAllCaleg(null, null, Sort.by(Sort.Direction.ASC, "nomorUrut"), 0))
+                .thenThrow(new RuntimeException("Service error"));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            calegController.getAllCaleg(null, null, Sort.Direction.ASC, 0);
+        });
+
+        assertEquals("Service error", exception.getMessage());
+        verify(calegService).getAllCaleg(null, null, Sort.by(Sort.Direction.ASC, "nomorUrut"), 0);
+    }
+
+    @Test
+    void testGetCalegById_success() {
+        DetailCalegDTO detailCalegDTO = new DetailCalegDTO();
+        detailCalegDTO.setId(dummyId);
+
+        when(calegService.getCalegById(dummyId)).thenReturn(detailCalegDTO);
+
+        ResponseEntity<DetailCalegDTO> response = calegController.getCalegById(dummyId);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(detailCalegDTO, response.getBody());
+        verify(calegService).getCalegById(dummyId);
+    }
+
+    @Test
+    void testGetCalegById_notFound() {
+        when(calegService.getCalegById(dummyId))
+                .thenThrow(new IllegalArgumentException("Caleg not found"));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            calegController.getCalegById(dummyId);
+        });
+
+        assertEquals("Caleg not found", exception.getMessage());
+        verify(calegService).getCalegById(dummyId);
+    }
+
+    @Test
+    void testGetCalegById_genericError() {
+        when(calegService.getCalegById(dummyId))
+                .thenThrow(new RuntimeException("Unexpected error"));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            calegController.getCalegById(dummyId);
+        });
+
+        assertEquals("Unexpected error", exception.getMessage());
+        verify(calegService).getCalegById(dummyId);
+    }
+}

--- a/src/test/java/com/allobank/allobackendtest/service/CalegServiceTest.java
+++ b/src/test/java/com/allobank/allobackendtest/service/CalegServiceTest.java
@@ -1,0 +1,183 @@
+package com.allobank.allobackendtest.service;
+
+import com.allobank.allobackendtest.dto.*;
+import com.allobank.allobackendtest.exception.ResourceNotFoundException;
+import com.allobank.allobackendtest.model.Caleg;
+import com.allobank.allobackendtest.model.Dapil;
+import com.allobank.allobackendtest.model.JenisKelamin;
+import com.allobank.allobackendtest.model.Partai;
+import com.allobank.allobackendtest.repository.CalegRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CalegServiceTest {
+
+    @Mock
+    private CalegRepository calegRepository;
+
+
+    @InjectMocks
+    private CalegService calegService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllCaleg_ReturnsList() {
+        UUID dapilId = UUID.randomUUID();
+        UUID partaiId = UUID.randomUUID();
+        Sort sort = Sort.by(Sort.Direction.ASC, "nomorUrut");
+        int page = 0;
+        Pageable pageable = PageRequest.of(page, 25, sort);
+
+        Caleg caleg = buildCaleg(dapilId, partaiId);
+        Page<Caleg> calegPage = new PageImpl<>(List.of(caleg), pageable, 1);
+
+        when(calegRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(calegPage);
+
+        PaginatedResponseDTO<CalegDTO> result = calegService.getAllCaleg(dapilId, partaiId, sort, page);
+
+        assertEquals(1, result.getTotalItems());
+        assertEquals(1, result.getTotalPages());
+        assertEquals(1, result.getData().size());
+        verify(calegRepository).findAll(any(Specification.class), eq(pageable));
+    }
+
+    @Test
+    void testGetAllCaleg_WithOnlyDapil() {
+        UUID dapilId = UUID.randomUUID();
+        Sort sort = Sort.by(Sort.Direction.DESC, "nama");
+        int page = 1;
+        Pageable pageable = PageRequest.of(page, 25, sort);
+
+        Caleg caleg = buildCaleg(dapilId, UUID.randomUUID());
+        Page<Caleg> pageResult = new PageImpl<>(List.of(caleg), pageable, 1);
+
+        when(calegRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(pageResult);
+
+        PaginatedResponseDTO<CalegDTO> result = calegService.getAllCaleg(dapilId, null, sort, page);
+
+        assertNotNull(result);
+        assertEquals(1, result.getData().size());
+    }
+
+    @Test
+    void testGetAllCaleg_WithOnlyPartai() {
+        UUID partaiId = UUID.randomUUID();
+        Sort sort = Sort.by(Sort.Direction.ASC, "id");
+        int page = 0;
+        Pageable pageable = PageRequest.of(page, 25, sort);
+
+        Caleg caleg = buildCaleg(UUID.randomUUID(), partaiId);
+        Page<Caleg> pageResult = new PageImpl<>(List.of(caleg), pageable, 1);
+
+        when(calegRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(pageResult);
+
+        PaginatedResponseDTO<CalegDTO> result = calegService.getAllCaleg(null, partaiId, sort, page);
+
+        assertEquals(1, result.getData().size());
+        assertEquals(1, result.getTotalItems());
+    }
+
+    @Test
+    void testGetAllCaleg_NullSort_UsesDefault() {
+        UUID dapilId = UUID.randomUUID();
+        UUID partaiId = UUID.randomUUID();
+        int page = 0;
+
+        Pageable pageable = PageRequest.of(page, 25, Sort.by(Sort.Direction.ASC, "nomorUrut"));
+        Caleg caleg = buildCaleg(dapilId, partaiId);
+        Page<Caleg> pageResult = new PageImpl<>(List.of(caleg), pageable, 1);
+
+        when(calegRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(pageResult);
+
+        PaginatedResponseDTO<CalegDTO> result = calegService.getAllCaleg(dapilId, partaiId, null, page);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalItems());
+    }
+
+    @Test
+    void testGetCalegById_ReturnsDetailCalegDTO() {
+        UUID id = UUID.randomUUID();
+        Caleg caleg = buildCaleg(UUID.randomUUID(), UUID.randomUUID());
+
+        when(calegRepository.findById(id)).thenReturn(Optional.of(caleg));
+
+        DetailCalegDTO result = calegService.getCalegById(id);
+        DetailCalegDTO expected = buildDetailCalegDTO(caleg);
+
+        assertNotNull(result);
+        assertEquals(caleg.getId(), result.getId());
+        assertEquals(caleg.getDapil().getNamaDapil(), result.getDapil().getNama());
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testGetCalegById_NotFound_ThrowsException() {
+        UUID id = UUID.randomUUID();
+        when(calegRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> calegService.getCalegById(id));
+    }
+
+    private Caleg buildCaleg(UUID dapilId, UUID partaiId) {
+        Dapil dapil = new Dapil();
+        dapil.setId(dapilId);
+        dapil.setNamaDapil("Jakarta I");
+        dapil.setProvinsi("DKI Jakarta");
+        dapil.setJumlahKursi(10);
+        dapil.setWilayahDapilList(List.of("Jakarta Selatan", "Jakarta Pusat"));
+
+        Partai partai = new Partai();
+        partai.setId(partaiId);
+        partai.setNamaPartai("Partai A");
+        partai.setNomorUrut(1);
+
+        Caleg caleg = new Caleg();
+        caleg.setId(UUID.randomUUID());
+        caleg.setNama("John Doe");
+        caleg.setNomorUrut(1);
+        caleg.setJenisKelamin(JenisKelamin.LAKILAKI);
+        caleg.setDapil(dapil);
+        caleg.setPartai(partai);
+
+        return caleg;
+    }
+
+    private DetailCalegDTO buildDetailCalegDTO(Caleg caleg) {
+        return DetailCalegDTO.builder()
+                .id(caleg.getId())
+                .nomorUrut(caleg.getNomorUrut())
+                .nama(caleg.getNama())
+                .jenisKelamin(caleg.getJenisKelamin())
+                .dapil(
+                        DetailDapilDTO.builder()
+                                .id(caleg.getDapil().getId())
+                                .nama(caleg.getDapil().getNamaDapil())
+                                .provinsi(caleg.getDapil().getProvinsi())
+                                .wilayah(caleg.getDapil().getWilayahDapilList())
+                                .jumlahKursi(caleg.getDapil().getJumlahKursi())
+                                .build()
+                )
+                .partai(
+                        PartaiDTO.builder()
+                                .id(caleg.getPartai().getId())
+                                .nama(caleg.getPartai().getNamaPartai())
+                                .nomorUrut(caleg.getPartai().getNomorUrut())
+                                .build()
+                )
+                .build();
+    }
+
+}


### PR DESCRIPTION
create api to retrive caleg data:

## End points
`GET /api/caleg` - Lists candidates with optional filtering and pagination
`GET /api/caleg/{id}` - Gets detailed info for a specific candidate

The controller connects to the existing CalegService, which uses Redis caching to improve performance. The service provides filtered, sorted, and paginated candidate data with proper DTO transformations.