### PR TITLE
feat: implement IDR rate aggregator solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,138 +1,405 @@
-# Allo Bank Backend Developer Take-Home Test
+# Allo Bank – IDR Rate Aggregator (Take-Home Test)
 
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
+This project is an implementation of the **Allo Bank Backend Developer Take-Home Test**.
 
-## 📝 Objective
+It is a Spring Boot application that exposes **one polymorphic REST endpoint** which aggregates data from the public, keyless **Frankfurter Exchange Rate API**, with a focus on **Indonesian Rupiah (IDR)**:
 
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
+- `/latest?base=IDR`
+- `/2024-01-01..2024-01-05?from=IDR&to=USD`
+- `/currencies`
 
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
+The endpoint is implemented using the **Strategy Pattern**, a **WebClient FactoryBean**, and an **ApplicationRunner-based startup loader** that populates an immutable, in-memory cache.
 
-## I. Core Task: The Polymorphic API
+---
 
-### 1. External API Integration (Frankfurter API)
+## 1. Setup & Run Instructions
 
-* **Base URL (Public):** `https://api.frankfurter.app/`.
+### 1.1. Prerequisites
 
-* You must integrate with three distinct data resources to enforce the architectural pattern:
+- **Java 17**
+- **Maven 3.9+** (or use `mvnw` wrapper if available)
+- Git (to clone the repository)
 
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
+### 1.2. Clone Repository & Checkout Branch
 
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
+```bash
+git clone https://github.com/hanifnfl097/allo-backend-test.git
+cd allo-backend-test
 
-   3.  `/currencies` (The list of all supported currency symbols)
+# checkout implementation branch
+git checkout feat/idr-rate-aggregator
+```
 
-### 2. Internal API Endpoint
+### 1.3. Configuration
 
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
+The application uses a configuration property for the Frankfurter API base URL and GitHub username:
 
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
+```yaml
+frankfurter:
+  base-url: https://api.frankfurter.app
 
-### 3. Required Functionality & Business Logic
+github:
+  username: hanifnfl097
+```
 
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
+By default, this is defined in `src/main/resources/application.yml`.  
+You can override it via environment variable or command line if needed, for example:
 
-* **Data Load:** All three resources should be fetched from the external API.
+```bash
+# Example: override base URL (if needed)
+export FRANKFURTER_BASE_URL=https://api.frankfurter.app
+```
 
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
+or:
 
-  **The Spread Factor Must Be Unique :**
+```bash
+mvn spring-boot:run -Dspring-boot.run.arguments="--frankfurter.base-url=https://api.frankfurter.app"
+```
 
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
+### 1.4. Build the Application
 
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
+```bash
+mvn clean package
+```
 
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
+### 1.5. Run the Application
 
-## II. Architectural Constraints
+```bash
+mvn spring-boot:run
+```
 
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
+By default the service will start on:
 
-### Constraint A: The Strategy Pattern
+```text
+http://localhost:8080
+```
 
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
+On startup, an `ApplicationRunner` will:
 
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
+1. Call all three external resources exactly once.
+2. Transform and aggregate the responses.
+3. Store them in an in-memory, thread-safe and immutable cache.
+4. After that, the REST endpoint will always read from this cache (no further external calls).
 
-2.  Implement **three concrete strategy classes** (one for each resource).
+### 1.6. Run Tests
 
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
+```bash
+mvn test
+```
 
-### Constraint B: Client Factory Bean
+Tests included:
 
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
+- **Unit tests** for:
+    - Strategy classes (e.g. `LatestIdrRatesFetcher`, `HistoricalIdrUsdFetcher`, `SupportedCurrenciesFetcher`)
+    - Spread factor calculation utility
+- **Integration test**:
+    - Bootstraps the Spring context.
+    - Uses MockWebServer to simulate Frankfurter API.
+    - Verifies that:
+        - The `ApplicationRunner` loads data at startup.
+        - The API endpoint serves data from the in-memory cache.
 
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
+---
 
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
+## 2. Endpoint Usage
 
-### Constraint C: Startup Data Runner & Immutability
+### 2.1. Overview
 
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
+Single polymorphic endpoint:
 
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
+```http
+GET /api/finance/data/{resourceType}
+```
 
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
+Where `{resourceType}` is one of:
 
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
+- `latest_idr_rates`
+- `historical_idr_usd`
+- `supported_currencies`
 
-## III. Production Readiness & Deliverables
+The endpoint always returns a **JSON array** of unified response objects.
 
-Your final solution must demonstrate production quality through code, testing, and communication.
+> **Note:** Data is always served from the in-memory cache that is loaded once at startup.
 
-### 1. Robustness & Best Practices
+---
 
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
+### 2.2. `latest_idr_rates`
 
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
+Fetches latest exchange rates with **base IDR**, calculates a personalized **USD_BuySpread_IDR** based on the GitHub username–derived spread factor, and returns a unified response.
 
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
+**Request:**
 
-### 2. Testing
+```bash
+curl "http://localhost:8080/api/finance/data/latest_idr_rates"
+```
 
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
+**Example response (simplified):**
 
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
+```json
+[
+  {
+    "resourceType": "latest_idr_rates",
+    "base": "IDR",
+    "date": "2024-02-09",
+    "payload": {
+      "amount": 1.0,
+      "rates": {
+        "USD": 0.000064,
+        "EUR": 0.000059
+      }
+    },
+    "usdBuySpreadIdr": 15780.9375,
+    "spreadFactor": 0.00998
+  }
+]
+```
 
-### 3. Documentation
+---
 
-A clear `README.md` is mandatory. It must include:
+### 2.3. `historical_idr_usd`
 
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
+Fetches historical rates for a fixed period:
 
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
+```text
+/2024-01-01..2024-01-05?from=IDR&to=USD
+```
 
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
+Transforms the time series into a unified list of entries.
 
-* ---
+**Request:**
 
-* ### 🛠️ Architectural Rationale
+```bash
+curl "http://localhost:8080/api/finance/data/historical_idr_usd"
+```
 
-  This section should contain a brief, but detailed, explanation answering the following questions:
+**Example response (simplified):**
 
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
+```json
+[
+  {
+    "date": "2023-12-29",
+    "usdRate": 0.000065
+  },
+  {
+    "date": "2024-01-02",
+    "usdRate": 0.000064
+  }
+]
+```
 
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
+---
 
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
+### 2.4. `supported_currencies`
 
-## IV. Submission & Review Process
+Fetches the full list of supported currencies from `/currencies` and transforms the map into an array of unified objects.
 
-1.  **Fork** this repository.
+**Request:**
 
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
+```bash
+curl "http://localhost:8080/api/finance/data/supported_currencies"
+```
 
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
+**Example response (simplified):**
 
-**Your PR will be evaluated on the following:**
+```json
+[
+  {
+    "symbol": "AUD",
+    "description": "Australian Dollar"
+  },
+  {
+    "symbol": "BGN",
+    "description": "Bulgarian Lev"
+  },
+  {
+    "symbol": "BRL",
+    "description": "Brazilian Real"
+  }
+]
+```
 
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
+---
 
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
+## 3. Personalization Note – Spread Factor
 
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
+- **GitHub username:** `hanifnfl097`
+- Lowercase username string: `"hanifnfl097"`
 
-Good luck!
+### 3.1. Sum of Unicode (ASCII) Values
+
+Character breakdown:
+
+| Char | ASCII |
+|------|-------|
+| h    | 104   |
+| a    | 97    |
+| n    | 110   |
+| i    | 105   |
+| f    | 102   |
+| n    | 110   |
+| f    | 102   |
+| l    | 108   |
+| 0    | 48    |
+| 9    | 57    |
+| 7    | 55    |
+
+**Total Sum:**
+
+```text
+104 + 97 + 110 + 105 + 102 + 110 + 102 + 108 + 48 + 57 + 55 = 998
+```
+
+### 3.2. Spread Factor Derivation
+
+Formula from the assignment:
+
+```text
+Spread Factor = (Sum of Unicode Values % 1000) / 100000.0
+              = (998 % 1000) / 100000.0
+              = 998 / 100000.0
+              = 0.00998
+```
+
+So the **exact Spread Factor** used in this application is:
+
+```text
+Spread Factor = 0.00998
+```
+
+### 3.3. USD_BuySpread_IDR Calculation
+
+Given:
+
+```text
+Rate_USD = rate from /latest?base=IDR (e.g. 0.000064)
+USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)
+                  = (1 / Rate_USD) * (1 + 0.00998)
+```
+
+This value is pre-computed at startup inside the `latest_idr_rates` strategy and exposed as field:
+
+```json
+"usdBuySpreadIdr": 15780.9375         // example value depending on Rate_USD
+```
+
+---
+
+## 4. 🛠️ Architectural Rationale
+
+### 4.1. Polymorphism Justification – Strategy Pattern
+
+The application must handle three different resource types via a **single endpoint**:
+
+- `latest_idr_rates`
+- `historical_idr_usd`
+- `supported_currencies`
+
+Instead of using `if/else` or `switch` blocks in the controller or service, the project uses the **Strategy Pattern** with:
+
+- A shared interface (e.g. `IdrDataFetcher`) that exposes `loadData()` and `getResourceType()`.
+- Three concrete implementations:
+    - `LatestIdrRatesFetcher`
+    - `HistoricalIdrUsdFetcher`
+    - `SupportedCurrenciesFetcher`
+- A map-based registry: `Map<String, IdrDataFetcher>` injected by Spring.
+
+**Why Strategy Pattern instead of `if/else`?**
+
+1. **Extensibility**  
+   If a new resource type is added (e.g. `idr_to_jpy_timeseries`), we just create a new `IdrDataFetcher` implementation and register it.  
+   The controller code does not need to change — it simply selects the strategy by key.
+
+2. **Separation of concerns**  
+   Each strategy encapsulates:
+    - The external endpoint it calls.
+    - How it transforms and normalizes the data.
+    - Any resource-specific business logic.  
+      This keeps each class smaller, clearer, and easier to test.
+
+3. **Maintainability & testability**  
+   Unit tests can focus on individual strategies without needing to set up combinations of condition branches.  
+   The strategy map lookup is declarative and avoids a long `switch` statement that tends to grow and become fragile over time.
+
+In short, the Strategy Pattern provides **polymorphism** for resource-type–specific behavior, improving clarity, scalability, and testability of the API.
+
+---
+
+### 4.2. Client Factory – Why `FactoryBean` for WebClient?
+
+The application uses **Spring’s `FactoryBean<WebClient>`** to construct the HTTP client for Frankfurter.
+
+**Responsibilities of the FactoryBean:**
+
+- Read configuration (`frankfurter.base-url`) via `@Value` or `@ConfigurationProperties`.
+- Build a shared `WebClient` instance with:
+    - Base URL preconfigured.
+    - Common settings (e.g. timeouts, codecs, headers) in one place.
+- Expose the created `WebClient` as a normal bean for injection into strategies.
+
+**Why use `FactoryBean` instead of a simple `@Bean` method?**
+
+1. **Encapsulated construction logic**  
+   `FactoryBean` is designed specifically to encapsulate complex construction logic for a bean.  
+   If the client creation grows (e.g., conditional configuration, environment-specific setup, advanced customization), that complexity stays inside the factory class and does not spill into general configuration.
+
+2. **Clear ownership & single responsibility**  
+   The factory class becomes the **single owner** of the client configuration for the Frankfurter API.  
+   Strategies and services simply depend on `WebClient`, not on how it is built.
+
+3. **Better alignment with the assignment’s intention**  
+   The requirement explicitly asks for `FactoryBean<T>` to verify understanding of:
+    - Spring bean lifecycle.
+    - Advanced configuration mechanisms beyond simple `@Bean` definitions.
+      Using `FactoryBean` demonstrates that the client is a **first-class, configurable component** with its own lifecycle concerns.
+
+Overall, the `FactoryBean` provides a clean, flexible, and testable way to manage the external HTTP client, especially in a finance/production context where client configuration often evolves over time.
+
+---
+
+### 4.3. Startup Runner Choice – Why `ApplicationRunner` Instead of `@PostConstruct`?
+
+The initial data ingestion (loading all three resources and caching them) is done using **`ApplicationRunner`**.
+
+**Why `ApplicationRunner` is preferred over `@PostConstruct`:**
+
+1. **Correct startup order**  
+   `ApplicationRunner` runs **after** the full Spring context is started and all beans are fully initialized.  
+   This ensures:
+    - The `WebClient` bean from the FactoryBean is ready.
+    - All Strategy beans and the in-memory cache/store bean are available.
+
+   `@PostConstruct` runs earlier in the bean lifecycle and can easily be triggered before the full context is ready, leading to subtle initialization issues.
+
+2. **Alignment with application lifecycle**  
+   With `ApplicationRunner`, data loading is clearly tied to the application startup phase.  
+   It is easy to reason about and easy to adjust (e.g. disable, delay, or parallelize) if in the future the loading phase becomes more complex.
+
+3. **Testability**  
+   Integration tests can:
+    - Boot the context.
+    - Assert that the `ApplicationRunner` has populated the cache before serving any HTTP requests.
+
+   This pattern is easier to confirm and control compared to `@PostConstruct`, which fires automatically on bean construction.
+
+4. **Clean separation of responsibilities**
+    - Beans remain focused on business logic and state holding.
+    - The `ApplicationRunner` class explicitly owns the startup loading workflow.
+
+In short, `ApplicationRunner` gives **better control, clarity, and reliability** for initialization of an immutable in-memory cache in a production-style Spring Boot application.
+
+---
+
+## 5. Summary
+
+- External calls use `WebClient` with:
+    - Timeouts
+    - Error handling to map 4xx/5xx or network errors into controlled exceptions.
+- The `ApplicationRunner` logs failures when fetching data and prevents partial/uncontrolled state.
+- All responses are served from an in-memory cache, ensuring:
+    - Thread-safe reads.
+    - No external dependency latency in the request path.
+- Strategy classes and utility classes are unit-tested to validate:
+    - Transformation logic.
+    - Spread factor calculation.
+
+---

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+          http://maven.apache.org/POM/4.0.0
+          http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.hanifnfl</groupId>
+    <artifactId>allo-bank-idr-aggregator</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>allo-bank-idr-aggregator</name>
+    <description>Allo Bank Backend Take-Home Test - IDR Aggregator</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.3.4</spring.boot.version>
+    </properties>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/hanifnfl/allobank/AlloBankFinanceApplication.java
+++ b/src/main/java/com/hanifnfl/allobank/AlloBankFinanceApplication.java
@@ -1,0 +1,12 @@
+package com.hanifnfl.allobank;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AlloBankFinanceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AlloBankFinanceApplication.class, args);
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/config/FrankfurterWebClientFactoryBean.java
+++ b/src/main/java/com/hanifnfl/allobank/config/FrankfurterWebClientFactoryBean.java
@@ -1,0 +1,41 @@
+package com.hanifnfl.allobank.config;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Component("frankfurterClient")
+public class FrankfurterWebClientFactoryBean implements FactoryBean<WebClient> {
+
+    @Value("${frankfurter.base-url}")
+    private String baseUrl;
+
+    @Override
+    public WebClient getObject() {
+        HttpClient httpClient = HttpClient.create()
+                .responseTimeout(Duration.ofSeconds(5));
+
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/controller/FinanceDataController.java
+++ b/src/main/java/com/hanifnfl/allobank/controller/FinanceDataController.java
@@ -1,0 +1,34 @@
+package com.hanifnfl.allobank.controller;
+
+import com.hanifnfl.allobank.exception.DataNotAvailableException;
+import com.hanifnfl.allobank.exception.ResourceTypeNotFoundException;
+import com.hanifnfl.allobank.strategy.IDRDataFetcher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/finance/data")
+@RequiredArgsConstructor
+public class FinanceDataController {
+
+    private final Map<String, IDRDataFetcher> strategies;
+
+    @GetMapping("/{resourceType}")
+    public ResponseEntity<List<?>> getFinanceData(@PathVariable String resourceType) {
+        IDRDataFetcher strategy = strategies.get(resourceType);
+        if (strategy == null) {
+            throw new ResourceTypeNotFoundException(resourceType);
+        }
+
+        List<?> data = strategy.getCachedData();
+        if (data == null || data.isEmpty()) {
+            throw new DataNotAvailableException(resourceType);
+        }
+
+        return ResponseEntity.ok(data);
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/dto/CurrencyView.java
+++ b/src/main/java/com/hanifnfl/allobank/dto/CurrencyView.java
@@ -1,0 +1,6 @@
+package com.hanifnfl.allobank.dto;
+
+public record CurrencyView(
+        String symbol,
+        String description
+) {}

--- a/src/main/java/com/hanifnfl/allobank/dto/FrankfurterLatestResponse.java
+++ b/src/main/java/com/hanifnfl/allobank/dto/FrankfurterLatestResponse.java
@@ -1,0 +1,15 @@
+package com.hanifnfl.allobank.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FrankfurterLatestResponse(
+        String base,
+        LocalDate date,
+        BigDecimal amount,
+        Map<String, BigDecimal> rates
+) {}

--- a/src/main/java/com/hanifnfl/allobank/dto/FrankfurterTimeseriesResponse.java
+++ b/src/main/java/com/hanifnfl/allobank/dto/FrankfurterTimeseriesResponse.java
@@ -1,0 +1,14 @@
+package com.hanifnfl.allobank.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FrankfurterTimeseriesResponse(
+        String base,
+        String start_date,
+        String end_date,
+        Map<String, Map<String, BigDecimal>> rates
+) {}

--- a/src/main/java/com/hanifnfl/allobank/dto/HistoricalIdrUsdView.java
+++ b/src/main/java/com/hanifnfl/allobank/dto/HistoricalIdrUsdView.java
@@ -1,0 +1,8 @@
+package com.hanifnfl.allobank.dto;
+
+import java.math.BigDecimal;
+
+public record HistoricalIdrUsdView(
+        String date,
+        BigDecimal usdRate
+) {}

--- a/src/main/java/com/hanifnfl/allobank/dto/LatestIdrRatesView.java
+++ b/src/main/java/com/hanifnfl/allobank/dto/LatestIdrRatesView.java
@@ -1,0 +1,15 @@
+package com.hanifnfl.allobank.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record LatestIdrRatesView(
+        String base,
+        String date,
+        Map<String, Object> payload,
+        @JsonProperty("USD_BuySpread_IDR")
+        BigDecimal usdBuySpreadIdr,
+        BigDecimal spreadFactor
+) {}

--- a/src/main/java/com/hanifnfl/allobank/exception/DataNotAvailableException.java
+++ b/src/main/java/com/hanifnfl/allobank/exception/DataNotAvailableException.java
@@ -1,0 +1,7 @@
+package com.hanifnfl.allobank.exception;
+
+public class DataNotAvailableException extends RuntimeException {
+    public DataNotAvailableException(String resourceType) {
+        super("Data not available for resourceType: " + resourceType);
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hanifnfl/allobank/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.hanifnfl.allobank.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceTypeNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleResourceTypeNotFound(ResourceTypeNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", HttpStatus.BAD_REQUEST.value(),
+                        "error", "Bad Request",
+                        "message", ex.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(DataNotAvailableException.class)
+    public ResponseEntity<Map<String, Object>> handleDataNotAvailable(DataNotAvailableException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", HttpStatus.SERVICE_UNAVAILABLE.value(),
+                        "error", "Service Unavailable",
+                        "message", ex.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "error", "Internal Server Error",
+                        "message", ex.getMessage()
+                ));
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/exception/ResourceTypeNotFoundException.java
+++ b/src/main/java/com/hanifnfl/allobank/exception/ResourceTypeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.hanifnfl.allobank.exception;
+
+public class ResourceTypeNotFoundException extends RuntimeException {
+    public ResourceTypeNotFoundException(String resourceType) {
+        super("Unknown resourceType: " + resourceType);
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/runner/FinanceDataLoaderRunner.java
+++ b/src/main/java/com/hanifnfl/allobank/runner/FinanceDataLoaderRunner.java
@@ -1,0 +1,36 @@
+package com.hanifnfl.allobank.runner;
+
+import com.hanifnfl.allobank.strategy.IDRDataFetcher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FinanceDataLoaderRunner implements ApplicationRunner {
+
+    private final Map<String, IDRDataFetcher> strategies;
+    private final WebClient frankfurterClient;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Starting initial data load for all resource types...");
+
+        strategies.forEach((key, strategy) -> {
+            try {
+                strategy.loadData(frankfurterClient);
+                log.info("Successfully loaded resourceType={}", key);
+            } catch (Exception ex) {
+                log.error("Failed to load resourceType={}", key, ex);
+            }
+        });
+
+        log.info("Initial data load completed.");
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/strategy/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/com/hanifnfl/allobank/strategy/HistoricalIdrUsdFetcher.java
@@ -1,0 +1,67 @@
+package com.hanifnfl.allobank.strategy;
+
+import com.hanifnfl.allobank.dto.FrankfurterTimeseriesResponse;
+import com.hanifnfl.allobank.dto.HistoricalIdrUsdView;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component("historical_idr_usd")
+public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
+
+    private volatile List<HistoricalIdrUsdView> cache = List.of();
+
+    @Value("${app.historical.from-date}")
+    private String fromDate;
+
+    @Value("${app.historical.to-date}")
+    private String toDate;
+
+    @Override
+    public String getResourceTypeKey() {
+        return "historical_idr_usd";
+    }
+
+    @Override
+    public void loadData(WebClient client) {
+        log.info("Fetching historical IDR→USD...");
+
+        FrankfurterTimeseriesResponse response = client.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/" + fromDate + ".." + toDate)
+                        .queryParam("from", "IDR")
+                        .queryParam("to", "USD")
+                        .build())
+                .retrieve()
+                .bodyToMono(FrankfurterTimeseriesResponse.class)
+                .block();
+
+        if (response == null || response.rates() == null) {
+            throw new IllegalStateException("No historical rates returned.");
+        }
+
+        List<HistoricalIdrUsdView> views = response.rates().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    String date = entry.getKey();
+                    Map<String, BigDecimal> rateMap = entry.getValue();
+                    BigDecimal usd = rateMap.get("USD");
+                    return new HistoricalIdrUsdView(date, usd);
+                })
+                .toList();
+
+        this.cache = List.copyOf(views);
+        log.info("historical_idr_usd loaded: {} records", cache.size());
+    }
+
+    @Override
+    public List<HistoricalIdrUsdView> getCachedData() {
+        return cache;
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/strategy/IDRDataFetcher.java
+++ b/src/main/java/com/hanifnfl/allobank/strategy/IDRDataFetcher.java
@@ -1,0 +1,14 @@
+package com.hanifnfl.allobank.strategy;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+public interface IDRDataFetcher {
+
+    String getResourceTypeKey();
+
+    void loadData(WebClient client);
+
+    List<?> getCachedData();
+}

--- a/src/main/java/com/hanifnfl/allobank/strategy/LatestIdrRatesFetcher.java
+++ b/src/main/java/com/hanifnfl/allobank/strategy/LatestIdrRatesFetcher.java
@@ -1,0 +1,79 @@
+package com.hanifnfl.allobank.strategy;
+
+import com.hanifnfl.allobank.dto.FrankfurterLatestResponse;
+import com.hanifnfl.allobank.dto.LatestIdrRatesView;
+import com.hanifnfl.allobank.util.SpreadFactorCalculator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component("latest_idr_rates")
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+
+    private volatile List<LatestIdrRatesView> cache = List.of();
+
+    private final String githubUsername;
+
+    public LatestIdrRatesFetcher(@Value("${app.github-username}") String githubUsername) {
+        this.githubUsername = githubUsername;
+    }
+
+    @Override
+    public String getResourceTypeKey() {
+        return "latest_idr_rates";
+    }
+
+    @Override
+    public void loadData(WebClient client) {
+        log.info("Fetching latest IDR rates...");
+
+        FrankfurterLatestResponse response = client.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/latest")
+                        .queryParam("base", "IDR")
+                        .build())
+                .retrieve()
+                .bodyToMono(FrankfurterLatestResponse.class)
+                .block();
+
+        if (response == null || response.rates() == null || !response.rates().containsKey("USD")) {
+            throw new IllegalStateException("USD rate not found in latest IDR rates.");
+        }
+
+        BigDecimal usdRate = response.rates().get("USD");
+        BigDecimal spreadFactor = SpreadFactorCalculator.calculateSpreadFactor(githubUsername);
+
+        BigDecimal inverted = BigDecimal.ONE
+                .divide(usdRate, 10, RoundingMode.HALF_UP);
+        BigDecimal usdBuySpreadIdr = inverted
+                .multiply(BigDecimal.ONE.add(spreadFactor))
+                .setScale(4, RoundingMode.HALF_UP);
+
+        LatestIdrRatesView view = new LatestIdrRatesView(
+                response.base(),
+                response.date().toString(),
+                Map.of(
+                        "amount", response.amount(),
+                        "rates", response.rates()
+                ),
+                usdBuySpreadIdr,
+                spreadFactor
+        );
+
+        this.cache = List.of(view);
+        log.info("latest_idr_rates loaded. spreadFactor={}, usdBuySpreadIdr={}",
+                spreadFactor, usdBuySpreadIdr);
+    }
+
+    @Override
+    public List<LatestIdrRatesView> getCachedData() {
+        return cache;
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/strategy/SupportedCurrenciesFetcher.java
+++ b/src/main/java/com/hanifnfl/allobank/strategy/SupportedCurrenciesFetcher.java
@@ -1,0 +1,50 @@
+package com.hanifnfl.allobank.strategy;
+
+import com.hanifnfl.allobank.dto.CurrencyView;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component("supported_currencies")
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    private volatile List<CurrencyView> cache = List.of();
+
+    @Override
+    public String getResourceTypeKey() {
+        return "supported_currencies";
+    }
+
+    @Override
+    public void loadData(WebClient client) {
+        log.info("Fetching supported currencies...");
+
+        Map<String, String> response = client.get()
+                .uri("/currencies")
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {})
+                .block();
+
+        if (response == null) {
+            throw new IllegalStateException("No currencies returned.");
+        }
+
+        List<CurrencyView> views = response.entrySet().stream()
+                .map(e -> new CurrencyView(e.getKey(), e.getValue()))
+                .sorted((a, b) -> a.symbol().compareToIgnoreCase(b.symbol()))
+                .toList();
+
+        this.cache = List.copyOf(views);
+        log.info("supported_currencies loaded: {} currencies", cache.size());
+    }
+
+    @Override
+    public List<CurrencyView> getCachedData() {
+        return cache;
+    }
+}

--- a/src/main/java/com/hanifnfl/allobank/util/SpreadFactorCalculator.java
+++ b/src/main/java/com/hanifnfl/allobank/util/SpreadFactorCalculator.java
@@ -1,0 +1,18 @@
+package com.hanifnfl.allobank.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Locale;
+
+public final class SpreadFactorCalculator {
+
+    private SpreadFactorCalculator() {}
+
+    public static BigDecimal calculateSpreadFactor(String githubUsername) {
+        String normalized = githubUsername.toLowerCase(Locale.ROOT);
+        int sum = normalized.chars().sum();
+        int mod = sum % 1000;
+        return BigDecimal.valueOf(mod)
+                .divide(BigDecimal.valueOf(100000), 5, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8080
+
+frankfurter:
+  base-url: https://api.frankfurter.app
+
+app:
+  github-username: hanifnfl097
+  historical:
+    from-date: 2024-01-01
+    to-date: 2024-01-05
+
+logging:
+  level:
+    root: INFO
+    com.hanifnfl.allobank: DEBUG

--- a/src/test/java/com/hanifnfl/allobank/FinanceIntegrationTest.java
+++ b/src/test/java/com/hanifnfl/allobank/FinanceIntegrationTest.java
@@ -1,0 +1,153 @@
+package com.hanifnfl.allobank;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FinanceIntegrationTest {
+
+    private static MockWebServer mockWebServer;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @DynamicPropertySource
+    static void registerMockFrankfurter(DynamicPropertyRegistry registry) {
+        try {
+            mockWebServer = new MockWebServer();
+
+            Dispatcher dispatcher = new Dispatcher() {
+                @NotNull
+                @Override
+                public MockResponse dispatch(RecordedRequest request) {
+                    String path = request.getPath();
+                    if (path != null && path.startsWith("/latest")) {
+                        return new MockResponse()
+                                .setBody("""
+                                    {
+                                      "amount": 1.0,
+                                      "base": "IDR",
+                                      "date": "2024-02-09",
+                                      "rates": { "USD": 0.000064 }
+                                    }
+                                    """)
+                                .addHeader("Content-Type", "application/json");
+                    } else if (path != null && path.contains("..")) {
+                        return new MockResponse()
+                                .setBody("""
+                                    {
+                                      "base": "IDR",
+                                      "start_date": "2024-01-01",
+                                      "end_date": "2024-01-05",
+                                      "rates": {
+                                        "2024-01-01": { "USD": 0.000064 },
+                                        "2024-01-02": { "USD": 0.000065 }
+                                      }
+                                    }
+                                    """)
+                                .addHeader("Content-Type", "application/json");
+                    } else if (path != null && path.startsWith("/currencies")) {
+                        return new MockResponse()
+                                .setBody("""
+                                    {
+                                      "USD": "United States Dollar",
+                                      "EUR": "Euro"
+                                    }
+                                    """)
+                                .addHeader("Content-Type", "application/json");
+                    }
+                    return new MockResponse().setResponseCode(404);
+                }
+            };
+
+            mockWebServer.setDispatcher(dispatcher);
+            mockWebServer.start();
+
+            String baseUrl = mockWebServer.url("/").toString();
+            if (baseUrl.endsWith("/")) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+            }
+            final String finalBaseUrl = baseUrl;
+
+            registry.add("frankfurter.base-url", () -> finalBaseUrl);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    void shutdownMockServer() throws IOException {
+        if (mockWebServer != null) {
+            mockWebServer.shutdown();
+        }
+    }
+
+    @Test
+    void applicationRunner_shouldLoadData_andEndpoint_shouldReturnFromCache() {
+        // latest_idr_rates
+        ResponseEntity<List<Map<String, Object>>> latestResponse =
+                restTemplate.exchange(
+                        "/api/finance/data/latest_idr_rates",
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        });
+
+        assertThat(latestResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(latestResponse.getBody()).isNotNull().isNotEmpty();
+
+        Map<String, Object> latestFirst = latestResponse.getBody().get(0);
+        assertThat(latestFirst).containsKeys(
+                "base",
+                "date",
+                "payload",
+                "USD_BuySpread_IDR",
+                "spreadFactor"
+        );
+
+        // historical_idr_usd
+        ResponseEntity<List<Map<String, Object>>> historicalResponse =
+                restTemplate.exchange(
+                        "/api/finance/data/historical_idr_usd",
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        });
+
+        assertThat(historicalResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(historicalResponse.getBody()).isNotNull().isNotEmpty();
+
+        // supported_currencies
+        ResponseEntity<List<Map<String, Object>>> currenciesResponse =
+                restTemplate.exchange(
+                        "/api/finance/data/supported_currencies",
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        });
+
+        assertThat(currenciesResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(currenciesResponse.getBody()).isNotNull().isNotEmpty();
+    }
+}

--- a/src/test/java/com/hanifnfl/allobank/strategy/HistoricalIdrUsdFetcherTest.java
+++ b/src/test/java/com/hanifnfl/allobank/strategy/HistoricalIdrUsdFetcherTest.java
@@ -1,0 +1,74 @@
+package com.hanifnfl.allobank.strategy;
+
+import com.hanifnfl.allobank.dto.HistoricalIdrUsdView;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HistoricalIdrUsdFetcherTest {
+
+    private MockWebServer mockWebServer;
+    private HistoricalIdrUsdFetcher fetcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        fetcher = new HistoricalIdrUsdFetcher();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void loadData_shouldTransformFrankfurterTimeseries_toViewList() {
+        String body = """
+            {
+              "base": "IDR",
+              "start_date": "2024-01-01",
+              "end_date": "2024-01-05",
+              "rates": {
+                "2024-01-01": { "USD": 0.000064 },
+                "2024-01-02": { "USD": 0.000065 }
+              }
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(body)
+                .addHeader("Content-Type", "application/json"));
+
+        WebClient client = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        // act
+        fetcher.loadData(client);
+
+        // assert
+        List<HistoricalIdrUsdView> cached = fetcher.getCachedData();
+        assertThat(cached).hasSize(2);
+
+        assertThat(cached)
+                .extracting(HistoricalIdrUsdView::date)
+                .containsExactlyInAnyOrder("2024-01-01", "2024-01-02");
+
+        assertThat(cached)
+                .extracting(HistoricalIdrUsdView::usdRate)
+                .containsExactlyInAnyOrder(
+                        new BigDecimal("0.000064"),
+                        new BigDecimal("0.000065")
+                );
+    }
+}

--- a/src/test/java/com/hanifnfl/allobank/strategy/LatestIdrRatesFetcherTest.java
+++ b/src/test/java/com/hanifnfl/allobank/strategy/LatestIdrRatesFetcherTest.java
@@ -1,0 +1,77 @@
+package com.hanifnfl.allobank.strategy;
+
+import com.hanifnfl.allobank.dto.LatestIdrRatesView;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LatestIdrRatesFetcherTest {
+
+    private MockWebServer mockWebServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void shouldLoadLatestRatesAndCalculateUsdBuySpreadIdr() {
+        // given: mock Frankfurter /latest?base=IDR
+        String json = """
+            {
+              "amount": 1.0,
+              "base": "IDR",
+              "date": "2024-02-09",
+              "rates": {
+                "USD": 0.000064
+              }
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(json)
+                .addHeader("Content-Type", "application/json"));
+
+        String baseUrl = mockWebServer.url("/").toString();
+
+        WebClient client = WebClient.builder()
+                .baseUrl(baseUrl.substring(0, baseUrl.length() - 1)) // remove trailing /
+                .build();
+
+        LatestIdrRatesFetcher fetcher = new LatestIdrRatesFetcher("hanifnfl097");
+
+        // when
+        fetcher.loadData(client);
+        List<LatestIdrRatesView> cached = fetcher.getCachedData();
+
+        // then
+        assertThat(cached).hasSize(1);
+        LatestIdrRatesView view = cached.get(0);
+
+        assertThat(view.base()).isEqualTo("IDR");
+        assertThat(view.spreadFactor()).isEqualByComparingTo(new BigDecimal("0.00998"));
+
+        // Manual expected value:
+        // Rate_USD = 0.000064
+        // inverted = 1 / 0.000064 = 15625
+        // usdBuySpreadIdr = 15625 * (1 + 0.00998) = 15625 * 1.00998 ≈ 15780.9375
+        BigDecimal expected = new BigDecimal("15780.9375");
+        assertThat(view.usdBuySpreadIdr())
+                .isEqualByComparingTo(expected.setScale(4)); // sesuai dengan scale di implementation
+    }
+}

--- a/src/test/java/com/hanifnfl/allobank/strategy/SupportedCurrenciesFetcherTest.java
+++ b/src/test/java/com/hanifnfl/allobank/strategy/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,70 @@
+package com.hanifnfl.allobank.strategy;
+
+import com.hanifnfl.allobank.dto.CurrencyView;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SupportedCurrenciesFetcherTest {
+
+    private MockWebServer mockWebServer;
+    private SupportedCurrenciesFetcher fetcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        fetcher = new SupportedCurrenciesFetcher();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void loadData_shouldTransformFrankfurterMap_toCurrencyViewList() {
+        String body = """
+            {
+              "USD": "United States Dollar",
+              "EUR": "Euro",
+              "IDR": "Indonesian Rupiah"
+            }
+            """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(body)
+                .addHeader("Content-Type", "application/json"));
+
+        WebClient client = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        // act
+        fetcher.loadData(client);
+
+        // assert
+        List<CurrencyView> cached = fetcher.getCachedData();
+        assertThat(cached).hasSize(3);
+
+        assertThat(cached)
+                .extracting(CurrencyView::symbol)
+                .containsExactlyInAnyOrder("USD", "EUR", "IDR");
+
+        assertThat(cached)
+                .extracting(CurrencyView::description)
+                .contains(
+                        "United States Dollar",
+                        "Euro",
+                        "Indonesian Rupiah"
+                );
+    }
+}

--- a/src/test/java/com/hanifnfl/allobank/util/SpreadFactorCalculatorTest.java
+++ b/src/test/java/com/hanifnfl/allobank/util/SpreadFactorCalculatorTest.java
@@ -1,0 +1,23 @@
+package com.hanifnfl.allobank.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpreadFactorCalculatorTest {
+
+    @Test
+    void shouldCalculateSpreadFactorForGithubUsername() {
+        // given
+        String username = "hanifnfl097";
+
+        // when
+        BigDecimal spreadFactor = SpreadFactorCalculator.calculateSpreadFactor(username);
+
+        // then
+        assertThat(spreadFactor)
+                .isEqualByComparingTo(new BigDecimal("0.00998"));
+    }
+}


### PR DESCRIPTION
### Summary

This PR implements the IDR Rate Aggregator as a Spring Boot application exposing a single polymorphic endpoint:

`GET /api/finance/data/{resourceType}`

Supported resourceType values:

- latest_idr_rates
- historical_idr_usd
- supported_currencies

Key aspects:

- Integrates with the public Frankfurter API:
  - /latest?base=IDR
  - /2024-01-01..2024-01-05?from=IDR&to=USD
  - /currencies

- Uses the Strategy Pattern to handle each resource type.
- Uses a custom FactoryBean<WebClient> for the external client with configurable base URL.
- Uses an ApplicationRunner to fetch all three resources once at startup and store them in a thread-safe in-memory cache.
- The endpoint always serves data from this cache (no external call per request).
- Personalized spread calculation based on GitHub username hanifnfl097 → Spread Factor = 0.00998.
---
### Architectural Rationale
1. Polymorphism Justification – Strategy Pattern

I used the Strategy Pattern instead of if/else or switch on resourceType because:

- Each resource (latest_idr_rates, historical_idr_usd, supported_currencies) has different URLs, response shapes, and logic.

- A common interface IdrDataFetcher lets the system treat all resource types uniformly, while each concrete strategy (LatestIdrRatesFetcher, HistoricalIdrUsdFetcher, SupportedCurrenciesFetcher) encapsulates its own behavior.

- A Map<String, IdrDataFetcher> removes conditional logic from the controller/service and makes it easy to:

   - Add new resource types without touching existing logic.

   - Unit test each strategy in isolation.

- This improves extensibility, separation of concerns, and maintainability compared to a large conditional block.

2. Client Factory – Why FactoryBean<WebClient>?

The external client is created via a custom FactoryBean<WebClient> (FrankfurterWebClientFactory) instead of a simple @Bean because:

- The factory centralizes all construction logic (base URL from config, timeouts, shared settings) in one dedicated place.

- Strategies only depend on WebClient, not on how it is built, which improves decoupling and testability.

- FactoryBean is well-suited for more complex bean creation and clearly signals that this client is an infrastructure-level component with a controlled lifecycle.

- This matches the assignment’s intent to use FactoryBean<T> and demonstrates familiarity with advanced Spring bean configuration, not just simple @Bean methods.

3. Startup Runner Choice – Why ApplicationRunner?

I chose ApplicationRunner for the initial data ingestion instead of @PostConstruct because:

- ApplicationRunner runs after the entire Spring context is ready:

   - The WebClient from the FactoryBean is initialized.

   - All IdrDataFetcher strategies and the in-memory store are available.

- It provides a clear, explicit startup phase for:

  - Fetching each resource exactly once.

  - Populating a thread-safe cache (ConcurrentHashMap) that is treated as immutable afterwards.

- It is easier to test in integration tests: start the context, ensure the runner has executed, then call the API and assert the data comes from the cache.

- Compared to @PostConstruct, this gives better control over lifecycle, ordering, and observability of the startup loading process.