### PR TITLE
Feat/tisnanda idr rate aggregator

### DIFF
--- a/allo-bank-backend-test/.gitattributes
+++ b/allo-bank-backend-test/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/allo-bank-backend-test/.gitignore
+++ b/allo-bank-backend-test/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea/
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/allo-bank-backend-test/.mvn/wrapper/maven-wrapper.properties
+++ b/allo-bank-backend-test/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/allo-bank-backend-test/README.md
+++ b/allo-bank-backend-test/README.md
@@ -37,11 +37,101 @@ resourceType options:
 * historical_idr_usd
 * supported_currencies
 
-Contoh cURL:
+Example cURL:
+
+respone sample with GlobalResponseFilter:
 
 * curl http://localhost:8089/api/finance/data/latest_idr_rates
+
+
+    
+    {
+        "code": "200",
+        "message": "Success",
+        "resource": "ALBS",
+        "data": [
+            {
+                "date": "2025-12-05",
+                "usd_BuySpread_IDR": 16821.833333333332,
+                "usd": 6.0E-5
+            }
+        ]
+    }
 * curl http://localhost:8089/api/finance/data/historical_idr_usd
+
+            {
+              "code": "200",
+              "message": "Success",
+              "resource": "ALBS",
+              "data": [
+                {
+                    "date": "2023-12-29",
+                    "USD": "6.5E-5"
+                },
+                {
+                    "date": "2024-01-02",
+                    "USD": "6.4E-5"
+                },
+                {
+                    "date": "2024-01-03",
+                    "USD": "6.4E-5"
+                },
+                {
+                    "date": "2024-01-04",
+                    "USD": "6.4E-5"
+                },
+                {
+                    "date": "2024-01-05",
+                    "USD": "6.4E-5"
+                }
+              ]
+            }
+
+
 * curl http://localhost:8089/api/finance/data/supported_currencies
+
+        {
+        "code": "200",
+        "message": "Success",
+        "resource": "ALBS",
+        "data": [
+            {
+                "currencies": {
+                        "AUD": "Australian Dollar",
+                        "BGN": "Bulgarian Lev",
+                        "BRL": "Brazilian Real",
+                        "CAD": "Canadian Dollar",
+                        "CHF": "Swiss Franc",
+                        "CNY": "Chinese Renminbi Yuan",
+                        "CZK": "Czech Koruna",
+                        "DKK": "Danish Krone",
+                        "EUR": "Euro",
+                        "GBP": "British Pound",
+                        "HKD": "Hong Kong Dollar",
+                        "HUF": "Hungarian Forint",
+                        "IDR": "Indonesian Rupiah",
+                        "ILS": "Israeli New Sheqel",
+                        "INR": "Indian Rupee",
+                        "ISK": "Icelandic Króna",
+                        "JPY": "Japanese Yen",
+                        "KRW": "South Korean Won",
+                        "MXN": "Mexican Peso",
+                        "MYR": "Malaysian Ringgit",
+                        "NOK": "Norwegian Krone",
+                        "NZD": "New Zealand Dollar",
+                        "PHP": "Philippine Peso",
+                        "PLN": "Polish Złoty",
+                        "RON": "Romanian Leu",
+                        "SEK": "Swedish Krona",
+                        "SGD": "Singapore Dollar",
+                        "THB": "Thai Baht",
+                        "TRY": "Turkish Lira",
+                        "USD": "United States Dollar",
+                        "ZAR": "South African Rand"
+                    }
+                }
+            ]
+        }
 
 
 🧑‍💻 Personalization
@@ -52,8 +142,8 @@ Spread Factor Calculation
 
 Formula:
 
-    Spread Factor = (sum of ASCII values of lowercase username % 1000) / 100000.0
-    Example Spread Factor: 0.00765
+    Sum of ASCII values of lowercase username: XXXX
+    Spread Factor = (XXXX % 1000) / 100000.0 = 0.YYYYY
 
     Formula untuk USD_BuySpread_IDR
     USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)

--- a/allo-bank-backend-test/README.md
+++ b/allo-bank-backend-test/README.md
@@ -16,7 +16,7 @@ Terima kasih sudah menilai aplikasi ini! Repository ini adalah solusi untuk take
 ```
  
 ```bash
-  ./mvnw spring-boot:run
+./mvnw spring-boot:run
 ```
 
 Requirements
@@ -52,8 +52,8 @@ respone sample with GlobalResponseFilter:
             "data": [
                 {
                     "date": "2025-12-05",
-                    "usd_BuySpread_IDR": 16821.833333333332,
-                    "usd": 6.0E-5
+                    "USD": 6.0E-5,
+                    "USD_BuySpread_IDR": 16821.833333333332
                 }
             ]
         }

--- a/allo-bank-backend-test/README.md
+++ b/allo-bank-backend-test/README.md
@@ -45,18 +45,19 @@ respone sample with GlobalResponseFilter:
 
 
     
-    {
-        "code": "200",
-        "message": "Success",
-        "resource": "ALBS",
-        "data": [
-            {
-                "date": "2025-12-05",
-                "usd_BuySpread_IDR": 16821.833333333332,
-                "usd": 6.0E-5
-            }
-        ]
-    }
+        {
+            "code": "200",
+            "message": "Success",
+            "resource": "ALBS",
+            "data": [
+                {
+                    "date": "2025-12-05",
+                    "usd_BuySpread_IDR": 16821.833333333332,
+                    "usd": 6.0E-5
+                }
+            ]
+        }
+
 * curl http://localhost:8089/api/finance/data/historical_idr_usd
 
             {

--- a/allo-bank-backend-test/README.md
+++ b/allo-bank-backend-test/README.md
@@ -1,23 +1,148 @@
 # Allo Bank Backend Developer Take-Home Test
 
-## Deskripsi
-Proyek ini adalah solusi untuk take-home test Allo Bank Backend Developer. Tujuannya adalah membuat **Spring Boot REST API** yang mengagregasi data dari **Frankfurter Exchange Rate API** untuk fokus pada mata uang **IDR (Indonesian Rupiah)**.
+Terima kasih sudah menilai aplikasi ini! Repository ini adalah solusi untuk take-home test Allo Bank yang berfokus pada pengolahan data keuangan IDR menggunakan Spring Boot.
 
-## Fitur
-- Endpoint: `GET /api/finance/data/{resourceType}`
-- Resource Types:
-    - `latest_idr_rates` → Mengembalikan kurs terbaru IDR dengan perhitungan **USD_BuySpread_IDR**
-    - `historical_idr_usd` → Mengembalikan data historis IDR ke USD
-    - `supported_currencies` → Mengembalikan daftar semua mata uang yang tersedia
-- Strategy Pattern untuk pemisahan logika fetch data
-- Data di-load sekali saat startup (ApplicationRunner) ke **in-memory store**
-- Thread-safe dan immutable
+---
 
-
-## Prasyarat
-- Java 17
-- Maven 3.5.8
-
-## Running
+🛠 Setup & Run Instructions
+1. Clone Repository
 ```bash
-./mvnw spring-boot:run
+   git clone <repository-url>
+```
+
+2. Build & Run
+  ```bash
+./mvnw clean install
+```
+ 
+```bash
+  ./mvnw spring-boot:run
+```
+
+Requirements
+
+* Java 17+
+
+* Maven 3.5.8+
+
+* Internet connection (hanya untuk initial data fetch, mocked in tests)
+
+📌 Endpoint Usage
+
+Endpoint utama:
+
+    GET /api/finance/data/{resourceType}
+resourceType options:
+* latest_idr_rates
+* historical_idr_usd
+* supported_currencies
+
+Contoh cURL:
+
+* curl http://localhost:8089/api/finance/data/latest_idr_rates
+* curl http://localhost:8089/api/finance/data/historical_idr_usd
+* curl http://localhost:8089/api/finance/data/supported_currencies
+
+
+🧑‍💻 Personalization
+
+GitHub Username: tisnandanurhidayat
+
+Spread Factor Calculation
+
+Formula:
+
+    Spread Factor = (sum of ASCII values of lowercase username % 1000) / 100000.0
+    Example Spread Factor: 0.00765
+
+    Formula untuk USD_BuySpread_IDR
+    USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)
+
+🏗 Architectural Rationale
+1. Polymorphism Justification (Strategy Pattern)
+
+Strategy Pattern digunakan untuk memisahkan logika pengambilan data pada tiga resource:
+
+* latest_idr_rates
+
+* historical_idr_usd
+
+* supported_currencies
+
+Keuntungan:
+
+* Mudah diperluas tanpa mengubah code yang sudah ada
+
+* Maintainable
+
+* Menghindari if/else atau switch yang kompleks di controller
+
+* Cleaner separation of concerns
+
+2. Client Factory (FactoryBean)
+
+FactoryBean digunakan untuk membuat instance RestTemplate (atau WebClient) dengan konfigurasi khusus seperti:
+
+* Base URL
+
+* Timeout
+
+* Global headers
+
+Keuntungan:
+
+* Client lebih konsisten
+
+* Konfigurasi dapat diatur lewat application.yml
+
+* Lebih fleksibel dibanding mendefinisikan @Bean biasa
+
+* Memisahkan creation logic dari application logic
+
+3. Startup Runner Choice (ApplicationRunner)
+
+ApplicationRunner digunakan untuk:
+
+* Preload seluruh data dari tiga resource
+
+* Menyimpan data ke in-memory store yang thread-safe dan immutable
+
+* Memastikan API tidak memanggil external API setiap request
+
+Keuntungan:
+
+* Lebih aman daripada @PostConstruct
+
+* Menjamin data tersedia sebelum aplikasi menerima request
+
+* Sesuai dengan production-grade initialization flow
+
+✅ Testing
+Unit Tests
+
+Semua strategy class diuji menggunakan mock RestTemplate
+
+Memverifikasi:
+
+* Transformasi data
+
+* Perhitungan USD_BuySpread_IDR
+
+Integration Tests
+
+* Memastikan ApplicationRunner preload data sebelum context fully started
+* Store terisi sebelum API digunakan
+
+Mocking External API
+
+* Tidak ada API nyata yang dipanggil selama testing
+
+📄 Notes
+
+* Semua resourceType mengembalikan JSON array yang konsisten
+
+* Supported currencies dan historical data menggunakan transformasi minimal
+
+* Latest IDR Rates memiliki perhitungan unik: USD_BuySpread_IDR
+
+* Data disajikan dari in-memory store, bukan hasil panggilan API realtime

--- a/allo-bank-backend-test/README.md
+++ b/allo-bank-backend-test/README.md
@@ -1,0 +1,23 @@
+# Allo Bank Backend Developer Take-Home Test
+
+## Deskripsi
+Proyek ini adalah solusi untuk take-home test Allo Bank Backend Developer. Tujuannya adalah membuat **Spring Boot REST API** yang mengagregasi data dari **Frankfurter Exchange Rate API** untuk fokus pada mata uang **IDR (Indonesian Rupiah)**.
+
+## Fitur
+- Endpoint: `GET /api/finance/data/{resourceType}`
+- Resource Types:
+    - `latest_idr_rates` → Mengembalikan kurs terbaru IDR dengan perhitungan **USD_BuySpread_IDR**
+    - `historical_idr_usd` → Mengembalikan data historis IDR ke USD
+    - `supported_currencies` → Mengembalikan daftar semua mata uang yang tersedia
+- Strategy Pattern untuk pemisahan logika fetch data
+- Data di-load sekali saat startup (ApplicationRunner) ke **in-memory store**
+- Thread-safe dan immutable
+
+
+## Prasyarat
+- Java 17
+- Maven 3.5.8
+
+## Running
+```bash
+./mvnw spring-boot:run

--- a/allo-bank-backend-test/mvnw
+++ b/allo-bank-backend-test/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/allo-bank-backend-test/mvnw.cmd
+++ b/allo-bank-backend-test/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/allo-bank-backend-test/pom.xml
+++ b/allo-bank-backend-test/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.8</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>id.tisnanda.allobank</groupId>
+	<artifactId>allo-bank-backend-test</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>allo-bank-backend-test</name>
+	<description>Allo Bank Backend Developer Take-Home Test - Spring Boot application for aggregating IDR currency data using Frankfurter API</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/AlloBankBackendTestApplication.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/AlloBankBackendTestApplication.java
@@ -1,0 +1,13 @@
+package id.tisnanda.allobank.allo_bank_backend_test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AlloBankBackendTestApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AlloBankBackendTestApplication.class, args);
+	}
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/config/AppStartupConfig.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/config/AppStartupConfig.java
@@ -1,0 +1,12 @@
+package id.tisnanda.allobank.allo_bank_backend_test.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppStartupConfig {
+    @Getter
+    @Setter
+    private boolean startupMode = true;
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/config/RestTemplateFactoryBean.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/config/RestTemplateFactoryBean.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Component

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/config/RestTemplateFactoryBean.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/config/RestTemplateFactoryBean.java
@@ -1,0 +1,66 @@
+package id.tisnanda.allobank.allo_bank_backend_test.config;
+
+import id.tisnanda.allobank.allo_bank_backend_test.middleware.RestClientLoggingMiddleware;
+import lombok.Setter;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class RestTemplateFactoryBean implements FactoryBean<RestTemplate> {
+
+
+    @Value("${frankfurter.api.base-url}")
+    private String baseUrl;
+
+    @Value("${frankfurter.api.timeout}")
+    private int timeout;
+
+    @Value("${frankfurter.api.headers.Accept}")
+    private String acceptHeader;
+
+    @Autowired(required = false)
+    RestClientLoggingMiddleware loggingMiddleware;
+
+    // Flag untuk menentukan apakah logging aktif
+    @Setter
+    private boolean enableLogging = true;
+
+
+    @Override
+    public RestTemplate getObject() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(timeout);
+        factory.setReadTimeout(timeout);
+
+        RestTemplate restTemplate = new RestTemplate(factory);
+
+        List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+        interceptors.add((request, body, execution) -> {
+            request.getHeaders().set("Accept", acceptHeader);
+            return execution.execute(request, body);
+        });
+
+        if (enableLogging && loggingMiddleware != null) {
+            interceptors.add(loggingMiddleware);
+        }
+
+        restTemplate.setInterceptors(interceptors);
+        return restTemplate;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return RestTemplate.class;
+    }
+
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/constant/Constant.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/constant/Constant.java
@@ -1,0 +1,46 @@
+package id.tisnanda.allobank.allo_bank_backend_test.constant;
+
+public class Constant {
+
+    public static final String RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND";
+    public static final String DATA_NOT_FOUND = "Data Not Found";
+    public static final String INTERNAL_SERVER_ERROR = "Internal server error";
+    public static final String RUNTIME_EXCEPTION = "RuntimeException";
+    public static final String INTERNAL_SERVER_ERROR_CODE = "500";
+    public static final String RESOURCE_NOT_FOUND_CODE = "404";
+    public static final String TEST_API_URI = "/api/test";
+    public static final String HISTORICAL_IDR_USD = "historical_idr_usd";
+    public static final String USD = "USD";
+    public static final String API_FAILED = "API failed";
+    public static final String FAILED_FETCH_HISTORICAL_IDR_USD_RATES = "Failed to fetch historical IDR->USD rates";
+    public static final String REST_TEMPLATE_NOT_SET = "RestTemplate must be set before fetching data";
+    public static final String MOCK_URL = "http://mock-url";
+    public static final String MOCK_URL_LATEST = "/latest?base=IDR";
+    public static final String TISNANDA_NUR_HIDAYAT = "tisnandanurhidayat";
+    public static final String FAILED_FETCH_LATEST_IDR_RATES = "Failed to fetch latest IDR rates";
+    public static final String IDR = "IDR";
+    public static final String MOCK_CURRENCIES_URL = "http://mock-currencies-url";
+    public static final String USD_CODE = "USD";
+    public static final String USD_NAME = "United States Dollar";
+    public static final String EUR_CODE = "EUR";
+    public static final String EUR_NAME = "Euro";
+    public static final String JPY_CODE = "JPY";
+    public static final String JPY_NAME = "Japanese Yen";
+    public static final String FAILED_FETCH_SUPPORTED_CURRENCIES = "Failed to fetch supported currencies";
+    public static final String UNEXPECTED_ERROR = "Unexpected error";
+
+    // Dates
+    public static final String DATE_2025_12_05 = "2025-12-05";
+    public static final String DATE_2025_12_06 = "2025-12-06";
+    public static final String DATE_2025_12_07 = "2025-12-07";
+
+    // Key
+    public static final String RATES_KEY = "rates";
+    public static final String BASE = "base";
+    public static final String DATE = "date";
+
+    // Values
+    public static final double RATE_15000 = 15000.0;
+    public static final double RATE_15100 = 15100.0;
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/controller/IDRDataController.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/controller/IDRDataController.java
@@ -1,0 +1,25 @@
+package id.tisnanda.allobank.allo_bank_backend_test.controller;
+
+
+import id.tisnanda.allobank.allo_bank_backend_test.service.IDRFinanceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/finance/data")
+public class IDRDataController {
+
+    @Autowired
+    private IDRFinanceService financeService;
+
+    @GetMapping("/{resourceType}")
+    public List<Map<String, Object>> getData(@PathVariable String resourceType) {
+        return financeService.getData(resourceType);
+    }
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/BaseResponse.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/BaseResponse.java
@@ -1,0 +1,24 @@
+package id.tisnanda.allobank.allo_bank_backend_test.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BaseResponse <T> {
+
+    private String code ;
+
+    private String message ;
+
+    private String resource ;
+
+    private T data;
+
+    public static <T> BaseResponse<T> success(T data) {
+        return new BaseResponse<>("200", "Success", "ALBS", data);
+    }
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/ErrorResponse.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/ErrorResponse.java
@@ -1,0 +1,16 @@
+package id.tisnanda.allobank.allo_bank_backend_test.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final String error;
+    private final String path;
+    private final String timestamp;
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/CurrenciesResponseDTO.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/CurrenciesResponseDTO.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.dto.strategy;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,6 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class LatestIDRRateResponseDTO {
-    private String date;
-    private Double USD;
-    private Double USD_BuySpread_IDR;
+public class CurrenciesResponseDTO {
+    private Map<String, String> currencies;
 }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/HistoricalIDRUSDResponseDTO.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/HistoricalIDRUSDResponseDTO.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 public class HistoricalIDRUSDResponseDTO {
     private String date;
 
-    @JsonSerialize(using = ToStringSerializer.class)
     @JsonProperty("USD")
     private Double usd;
 }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/HistoricalIDRUSDResponseDTO.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/HistoricalIDRUSDResponseDTO.java
@@ -1,0 +1,20 @@
+package id.tisnanda.allobank.allo_bank_backend_test.dto.strategy;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class HistoricalIDRUSDResponseDTO {
+    private String date;
+
+    @JsonSerialize(using = ToStringSerializer.class)
+    @JsonProperty("USD")
+    private Double usd;
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/HistoricalIDRUSDResponseDTO.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/HistoricalIDRUSDResponseDTO.java
@@ -2,8 +2,6 @@ package id.tisnanda.allobank.allo_bank_backend_test.dto.strategy;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/LatestIDRRateResponseDTO.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/LatestIDRRateResponseDTO.java
@@ -1,0 +1,16 @@
+package id.tisnanda.allobank.allo_bank_backend_test.dto.strategy;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LatestIDRRateResponseDTO {
+    private String date;
+    private String base;
+    private Map<String, Double> rates;
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/LatestIDRRateResponseDTO.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/dto/strategy/LatestIDRRateResponseDTO.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.dto.strategy;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,11 @@ import java.util.Map;
 @AllArgsConstructor
 public class LatestIDRRateResponseDTO {
     private String date;
-    private Double USD;
-    private Double USD_BuySpread_IDR;
+
+    @JsonProperty("USD")
+
+    private Double usd;
+
+    @JsonProperty("USD_BuySpread_IDR")
+    private Double usdBuySpreedIDR;
 }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/AlloBankException.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/AlloBankException.java
@@ -1,0 +1,19 @@
+package id.tisnanda.allobank.allo_bank_backend_test.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AlloBankException extends RuntimeException {
+
+    private final ErrorCodes errorCodes;
+
+    public AlloBankException(String message, ErrorCodes errorCodes) {
+        super(message);
+        this.errorCodes = errorCodes;
+    }
+
+    public AlloBankException(String message, Throwable cause, ErrorCodes errorCodes) {
+        super(message, cause);
+        this.errorCodes = errorCodes;
+    }
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/BadRequestException.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package id.tisnanda.allobank.allo_bank_backend_test.exception;
+
+public class BadRequestException extends AlloBankException {
+    public BadRequestException(String message) {
+        super(message , ErrorCodes.INVALID_REQUEST);
+    }
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/ErrorCodes.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/ErrorCodes.java
@@ -1,0 +1,17 @@
+package id.tisnanda.allobank.allo_bank_backend_test.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCodes {
+
+    RESOURCE_NOT_FOUND("RESOURCE_NOT_FOUND", 404),
+    INVALID_REQUEST("INVALID_REQUEST", 400),
+    INTERNAL_ERROR("INTERNAL_ERROR", 500);
+
+    private final String code;
+    private final int httpStatus;
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/ResourceNotFoundException.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package id.tisnanda.allobank.allo_bank_backend_test.exception;
+
+public class ResourceNotFoundException extends AlloBankException {
+    public ResourceNotFoundException(String message) {
+        super(message , ErrorCodes.RESOURCE_NOT_FOUND);
+    }
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandler.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,71 @@
+package id.tisnanda.allobank.allo_bank_backend_test.exception.handler;
+
+import id.tisnanda.allobank.allo_bank_backend_test.dto.ErrorResponse;
+import id.tisnanda.allobank.allo_bank_backend_test.exception.AlloBankException;
+import id.tisnanda.allobank.allo_bank_backend_test.exception.ErrorCodes;
+import id.tisnanda.allobank.allo_bank_backend_test.util.DateUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import org.jboss.logging.Logger;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger log = Logger.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(AlloBankException.class)
+    public ResponseEntity<ErrorResponse> handleAlloBankException(AlloBankException ex, HttpServletRequest request) {
+
+        ErrorCodes code = ex.getErrorCodes();
+
+        log.warnf("Handled exception occurred: %s - %s, path=%s",
+                code.name(),
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+
+        ErrorResponse response = new ErrorResponse(
+                String.valueOf(code.getHttpStatus()),
+                ex.getMessage(),
+                code.name(),
+                request.getRequestURI(),
+                DateUtils.formatLocalDateTime(LocalDateTime.now())
+        );
+
+        return ResponseEntity.status(code.getHttpStatus()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception ex, HttpServletRequest request) {
+
+        StackTraceElement element = ex.getStackTrace()[0];
+        log.errorf(ex,
+                "Unhandled exception: class=%s, method=%s, exception=%s, message=%s, path=%s",
+                element.getClassName(),
+                element.getMethodName(),
+                ex.getClass().getSimpleName(),
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+
+        ErrorResponse response = new ErrorResponse(
+                "500",
+                ex.getMessage() != null ? ex.getMessage() : "Unexpected error",
+                ex.getClass().getSimpleName(),
+                request.getRequestURI(),
+                DateUtils.formatLocalDateTime(LocalDateTime.now())
+        );
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandler.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ErrorCodes code = ex.getErrorCodes();
 
-        log.warnf("Handled exception occurred: %s - %s, path=%s",
+        log.errorf("Handled exception occurred: %s - %s, path=%s",
                 code.name(),
                 ex.getMessage(),
                 request.getRequestURI()

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandler.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.exception.handler;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.ErrorResponse;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.AlloBankException;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.ErrorCodes;
@@ -21,13 +22,14 @@ import java.time.LocalDateTime;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final Logger log = Logger.getLogger(GlobalExceptionHandler.class);
+    private static final Logger alloBankLog = Logger.getLogger(AlloBankException.class);
 
     @ExceptionHandler(AlloBankException.class)
     public ResponseEntity<ErrorResponse> handleAlloBankException(AlloBankException ex, HttpServletRequest request) {
-
         ErrorCodes code = ex.getErrorCodes();
 
-        log.errorf("Handled exception occurred: %s - %s, path=%s",
+        alloBankLog.errorf("Handled exception occurred: %s - %s, path=%s",
+
                 code.name(),
                 ex.getMessage(),
                 request.getRequestURI()
@@ -58,8 +60,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         );
 
         ErrorResponse response = new ErrorResponse(
-                "500",
-                ex.getMessage() != null ? ex.getMessage() : "Unexpected error",
+                Constant.INTERNAL_SERVER_ERROR_CODE,
+                ex.getMessage() != null ? ex.getMessage() : Constant.UNEXPECTED_ERROR,
                 ex.getClass().getSimpleName(),
                 request.getRequestURI(),
                 DateUtils.formatLocalDateTime(LocalDateTime.now())

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/filter/GlobalResponseFilter.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/filter/GlobalResponseFilter.java
@@ -1,0 +1,41 @@
+package id.tisnanda.allobank.allo_bank_backend_test.filter;
+
+
+import id.tisnanda.allobank.allo_bank_backend_test.dto.BaseResponse;
+import id.tisnanda.allobank.allo_bank_backend_test.dto.ErrorResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@ControllerAdvice
+public class GlobalResponseFilter implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports (MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+
+        int status = 200;
+        if (response instanceof ServletServerHttpResponse) {
+            status = ((ServletServerHttpResponse) response).getServletResponse().getStatus();
+        }
+
+        if (status >= 300 ||body instanceof BaseResponse || body instanceof ErrorResponse) {
+            return body;
+        }
+
+        return BaseResponse.success(body);
+    }
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/middleware/RestClientLoggingMiddleware.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/middleware/RestClientLoggingMiddleware.java
@@ -1,0 +1,104 @@
+package id.tisnanda.allobank.allo_bank_backend_test.middleware;
+
+import id.tisnanda.allobank.allo_bank_backend_test.config.AppStartupConfig;
+import org.jboss.logging.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+
+@Component
+public class RestClientLoggingMiddleware implements ClientHttpRequestInterceptor {
+
+    private static final Logger log = Logger.getLogger(RestClientLoggingMiddleware.class);
+
+    @Autowired
+    private AppStartupConfig startupConfig;
+
+    private static final List<String> SENSITIVE_HEADERS = List.of(
+            "apiKey", "authorization", "x-api-key", "x-consumer-custom-id"
+    );
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body,
+                                        ClientHttpRequestExecution execution) throws IOException {
+        try {
+
+            if (startupConfig.isStartupMode()) {
+                return execution.execute(request, body);
+            }
+
+            logRequest(request, body);
+
+            ClientHttpResponse response = execution.execute(request, body);
+
+            logResponse(request, response);
+
+            return response;
+        } catch (IOException e) {
+            log.errorf(e, "HTTP request failed: %s %s", request.getMethod(), request.getURI());
+            throw e;
+        }
+    }
+
+    private void logRequest(HttpRequest request, byte[] body) {
+        log.infof(
+                "REST-REQ %s %s headers=%s body=%s",
+                request.getMethod(),
+                request.getURI(),
+                maskHeaders(request.getHeaders()),
+                new String(body, StandardCharsets.UTF_8)
+        );
+    }
+
+    private void logResponse(HttpRequest request, ClientHttpResponse response) throws IOException {
+        byte[] body = readResponseBody(response);
+        log.infof(
+                "REST-RES %s %s -> %d headers=%s body=%s",
+                request.getMethod(),
+                request.getURI(),
+                response.getStatusCode().value(),
+                maskHeaders(response.getHeaders()),
+                new String(body, StandardCharsets.UTF_8)
+        );
+    }
+
+    private byte[] readResponseBody(ClientHttpResponse response) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            response.getBody().transferTo(baos);
+            return baos.toByteArray();
+        }
+    }
+
+    private String maskHeaders(HttpHeaders headers) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (!first) sb.append(", ");
+            first = false;
+
+            String key = entry.getKey();
+            String value = entry.getValue().toString();
+
+            if (SENSITIVE_HEADERS.stream().anyMatch(h -> h.equalsIgnoreCase(key))) {
+                value = "[REDACTED]";
+            }
+
+            sb.append(key).append("=").append(value);
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoader.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoader.java
@@ -34,6 +34,7 @@ public class IDRDataLoader implements ApplicationRunner {
                 financeService.setData(resourceType, data);
             } catch (Exception e) {
                 log.errorf(e, "Failed to fetch data for resource: %s", resourceType);
+                throw new IllegalStateException("Startup aborted: cannot load required data");
             }
         });
 

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoader.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoader.java
@@ -1,0 +1,42 @@
+package id.tisnanda.allobank.allo_bank_backend_test.runner;
+
+import id.tisnanda.allobank.allo_bank_backend_test.service.IDRFinanceService;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
+import lombok.RequiredArgsConstructor;
+import org.jboss.logging.Logger;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class IDRDataLoader implements ApplicationRunner {
+
+    private static final Logger log = Logger.getLogger(IDRDataLoader.class);
+
+    private final IDRFinanceService financeService;
+    private final Map<String, IDRDataFetcher> dataFetchers;
+
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (dataFetchers == null) {
+            log.warn("No data fetchers configured");
+            return;
+        }
+
+        dataFetchers.forEach((resourceType, fetcher) -> {
+            try {
+                List<Map<String, Object>> data = fetcher.fetchData();
+                financeService.setData(resourceType, data);
+            } catch (Exception e) {
+                log.errorf(e, "Failed to fetch data for resource: %s", resourceType);
+            }
+        });
+
+        log.info("Startup data loaded successfully!");
+    }
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/service/IDRFinanceService.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/service/IDRFinanceService.java
@@ -1,0 +1,32 @@
+package id.tisnanda.allobank.allo_bank_backend_test.service;
+
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.ResourceNotFoundException;
+import org.jboss.logging.Logger;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class IDRFinanceService {
+
+    private static final Logger log = Logger.getLogger(IDRFinanceService.class);
+
+    private final Map<String, List<Map<String, Object>>> dataStore = new ConcurrentHashMap<>();
+
+    public void setData(String resourceType, List<Map<String, Object>> data) {
+        dataStore.put(resourceType, Collections.unmodifiableList(data));
+    }
+
+    public List<Map<String, Object>> getData(String resourceType) {
+        List<Map<String, Object>> data = dataStore.get(resourceType);
+        if (data == null) {
+            throw new ResourceNotFoundException(resourceType);
+        }
+        return dataStore.getOrDefault(resourceType, Collections.emptyList());
+    }
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/IDRDataFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/IDRDataFetcher.java
@@ -1,0 +1,15 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy;
+
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+public interface IDRDataFetcher {
+
+    /**
+     * Ambil data dari external API
+     */
+    List<Map<String, Object>> fetchData();
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/IDRDataFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/IDRDataFetcher.java
@@ -1,9 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
-import org.springframework.web.client.RestTemplate;
-
 import java.util.List;
-import java.util.Map;
 
 public interface IDRDataFetcher<T> {
 

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/IDRDataFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/IDRDataFetcher.java
@@ -5,11 +5,8 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 import java.util.Map;
 
-public interface IDRDataFetcher {
+public interface IDRDataFetcher<T> {
 
-    /**
-     * Ambil data dari external API
-     */
-    List<Map<String, Object>> fetchData();
+    List<T> fetchData();
 
 }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
@@ -1,0 +1,50 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component("historical_idr_usd")
+public class HistoricalIDRUSDFetcher implements IDRDataFetcher {
+
+    @Value("${external.frankfurter.historical-url}")
+    public String historicalUrl;
+
+    @Autowired
+    public RestTemplate restTemplate;
+
+    @Override
+    public List<Map<String, Object>> fetchData() {
+        if (restTemplate == null) {
+            throw new BadRequestException("RestTemplate must be set before fetching data");
+        }
+
+        Map<String, Object> response = restTemplate.getForObject(historicalUrl, Map.class);
+
+        if (response == null || !response.containsKey("rates")) {
+            throw new BadRequestException("Failed to fetch historical IDR->USD rates");
+        }
+
+        Map<String, Object> rates = (Map<String, Object>) response.get("rates");
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map.Entry<String, Object> entry : rates.entrySet()) {
+            Map<String, Object> record = new HashMap<>();
+            record.put("date", entry.getKey());
+            Map<String, Object> usdMap = (Map<String, Object>) entry.getValue();
+            record.put("USD", usdMap.get("USD"));
+            result.add(record);
+        }
+
+        return result;
+    }
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
@@ -25,10 +25,6 @@ public class HistoricalIDRUSDFetcher implements IDRDataFetcher<HistoricalIDRUSDR
     @Override
     public List<HistoricalIDRUSDResponseDTO> fetchData() {
 
-        if (restTemplate == null) {
-            throw new BadRequestException(Constant.REST_TEMPLATE_NOT_SET);
-        }
-
         Map<String, Object> response = restTemplate.getForObject(historicalUrl, Map.class);
 
         if (response == null || !response.containsKey(Constant.RATES_KEY)) {

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.HistoricalIDRUSDResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
@@ -25,22 +26,22 @@ public class HistoricalIDRUSDFetcher implements IDRDataFetcher<HistoricalIDRUSDR
     public List<HistoricalIDRUSDResponseDTO> fetchData() {
 
         if (restTemplate == null) {
-            throw new BadRequestException("RestTemplate must be set before fetching data");
+            throw new BadRequestException(Constant.REST_TEMPLATE_NOT_SET);
         }
 
         Map<String, Object> response = restTemplate.getForObject(historicalUrl, Map.class);
 
-        if (response == null || !response.containsKey("rates")) {
-            throw new BadRequestException("Failed to fetch historical IDR->USD rates");
+        if (response == null || !response.containsKey(Constant.RATES_KEY)) {
+            throw new BadRequestException(Constant.FAILED_FETCH_HISTORICAL_IDR_USD_RATES);
         }
 
-        Map<String, Map<String, Object>> rates = (Map<String, Map<String, Object>>) response.get("rates");
+        Map<String, Map<String, Object>> rates = (Map<String, Map<String, Object>>) response.get(Constant.RATES_KEY);
         List<HistoricalIDRUSDResponseDTO> result = new ArrayList<>();
 
         for (Map.Entry<String, Map<String, Object>> entry : rates.entrySet()) {
             String date = entry.getKey();
             Map<String, Object> usdMap = entry.getValue();
-            Double usdValue = ((Number) usdMap.get("USD")).doubleValue();
+            Double usdValue = ((Number) usdMap.get(Constant.USD)).doubleValue();
 
             result.add(new HistoricalIDRUSDResponseDTO(date, usdValue));
         }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/HistoricalIDRUSDFetcher.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
+import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.HistoricalIDRUSDResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,12 +9,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @Component("historical_idr_usd")
-public class HistoricalIDRUSDFetcher implements IDRDataFetcher {
+public class HistoricalIDRUSDFetcher implements IDRDataFetcher<HistoricalIDRUSDResponseDTO> {
 
     @Value("${external.frankfurter.historical-url}")
     public String historicalUrl;
@@ -22,7 +22,8 @@ public class HistoricalIDRUSDFetcher implements IDRDataFetcher {
     public RestTemplate restTemplate;
 
     @Override
-    public List<Map<String, Object>> fetchData() {
+    public List<HistoricalIDRUSDResponseDTO> fetchData() {
+
         if (restTemplate == null) {
             throw new BadRequestException("RestTemplate must be set before fetching data");
         }
@@ -33,15 +34,15 @@ public class HistoricalIDRUSDFetcher implements IDRDataFetcher {
             throw new BadRequestException("Failed to fetch historical IDR->USD rates");
         }
 
-        Map<String, Object> rates = (Map<String, Object>) response.get("rates");
+        Map<String, Map<String, Object>> rates = (Map<String, Map<String, Object>>) response.get("rates");
+        List<HistoricalIDRUSDResponseDTO> result = new ArrayList<>();
 
-        List<Map<String, Object>> result = new ArrayList<>();
-        for (Map.Entry<String, Object> entry : rates.entrySet()) {
-            Map<String, Object> record = new HashMap<>();
-            record.put("date", entry.getKey());
-            Map<String, Object> usdMap = (Map<String, Object>) entry.getValue();
-            record.put("USD", usdMap.get("USD"));
-            result.add(record);
+        for (Map.Entry<String, Map<String, Object>> entry : rates.entrySet()) {
+            String date = entry.getKey();
+            Map<String, Object> usdMap = entry.getValue();
+            Double usdValue = ((Number) usdMap.get("USD")).doubleValue();
+
+            result.add(new HistoricalIDRUSDResponseDTO(date, usdValue));
         }
 
         return result;

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
@@ -2,9 +2,11 @@ package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.LatestIDRRateResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.exception.handler.GlobalExceptionHandler;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
 import lombok.Getter;
 import lombok.Setter;
+import org.jboss.logging.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,6 +21,8 @@ import java.util.Map;
 @Setter
 @Getter
 public class LatestIDRRatesFetcher implements IDRDataFetcher<LatestIDRRateResponseDTO> {
+
+    private static final Logger log = Logger.getLogger(LatestIDRRatesFetcher.class);
 
     @Autowired
     RestTemplate restTemplate;
@@ -41,6 +45,7 @@ public class LatestIDRRatesFetcher implements IDRDataFetcher<LatestIDRRateRespon
         Map<String, Object> rates = (Map<String, Object>) response.get("rates");
         double rateUSD = ((Number) rates.get("USD")).doubleValue();
         double spreadFactor = calculateSpreadFactor(githubUsername);
+        log.info("spreadFactor : " + spreadFactor);
         double usdBuySpread = (1 / rateUSD) * (1 + spreadFactor);
 
         Map<String, Double> mappedRates = Map.of("IDR", usdBuySpread);

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
@@ -1,36 +1,36 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
+import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.LatestIDRRateResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
+import lombok.Getter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @Component("latest_idr_rates")
 @Setter
-public class LatestIDRRatesFetcher implements IDRDataFetcher {
+@Getter
+public class LatestIDRRatesFetcher implements IDRDataFetcher<LatestIDRRateResponseDTO> {
 
     @Autowired
-    public RestTemplate restTemplate;
+    RestTemplate restTemplate;
 
     @Value("${external.frankfurter.latest-url}")
-    public String latestUrl;
+    String latestUrl;
 
     @Value("${spread.github-username}")
-    public String githubUsername;
+    String githubUsername;
 
     @Override
-    public List<Map<String, Object>> fetchData() {
-        if (restTemplate == null) {
-            throw new BadRequestException("RestTemplate must be set before fetching data");
-        }
+    public List<LatestIDRRateResponseDTO> fetchData() {
 
         Map<String, Object> response = restTemplate.getForObject(latestUrl, Map.class);
 
@@ -39,23 +39,23 @@ public class LatestIDRRatesFetcher implements IDRDataFetcher {
         }
 
         Map<String, Object> rates = (Map<String, Object>) response.get("rates");
-
+        double rateUSD = ((Number) rates.get("USD")).doubleValue();
         double spreadFactor = calculateSpreadFactor(githubUsername);
+        double usdBuySpread = (1 / rateUSD) * (1 + spreadFactor);
 
-        Map<String, Object> transformed = new HashMap<>(rates);
+        Map<String, Double> mappedRates = Map.of("IDR", usdBuySpread);
 
-        if (rates.containsKey("USD")) {
-            double rateUSD = ((Number) rates.get("USD")).doubleValue();
-            double usdBuySpread = (1 / rateUSD) * (1 + spreadFactor);
-            transformed.put("USD_BuySpread_IDR", usdBuySpread);
-        }
+        LatestIDRRateResponseDTO dto = new LatestIDRRateResponseDTO(
+                (String) response.getOrDefault("date", LocalDate.now().toString()),
+                rateUSD,
+                usdBuySpread
+        );
 
-        return Collections.singletonList(transformed);
+        return Collections.singletonList(dto);
     }
 
-    private double calculateSpreadFactor(String username) {
-        username = username.toLowerCase();
-        int sum = username.chars().sum();
+    public double calculateSpreadFactor(String username) {
+        int sum = username.toLowerCase().chars().sum();
         return (sum % 1000) / 100000.0;
     }
 

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
@@ -1,0 +1,62 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component("latest_idr_rates")
+@Setter
+public class LatestIDRRatesFetcher implements IDRDataFetcher {
+
+    @Autowired
+    public RestTemplate restTemplate;
+
+    @Value("${external.frankfurter.latest-url}")
+    public String latestUrl;
+
+    @Value("${spread.github-username}")
+    public String githubUsername;
+
+    @Override
+    public List<Map<String, Object>> fetchData() {
+        if (restTemplate == null) {
+            throw new BadRequestException("RestTemplate must be set before fetching data");
+        }
+
+        Map<String, Object> response = restTemplate.getForObject(latestUrl, Map.class);
+
+        if (response == null || !response.containsKey("rates")) {
+            throw new BadRequestException("Failed to fetch latest IDR rates");
+        }
+
+        Map<String, Object> rates = (Map<String, Object>) response.get("rates");
+
+        double spreadFactor = calculateSpreadFactor(githubUsername);
+
+        Map<String, Object> transformed = new HashMap<>(rates);
+
+        if (rates.containsKey("USD")) {
+            double rateUSD = ((Number) rates.get("USD")).doubleValue();
+            double usdBuySpread = (1 / rateUSD) * (1 + spreadFactor);
+            transformed.put("USD_BuySpread_IDR", usdBuySpread);
+        }
+
+        return Collections.singletonList(transformed);
+    }
+
+    private double calculateSpreadFactor(String username) {
+        username = username.toLowerCase();
+        int sum = username.chars().sum();
+        return (sum % 1000) / 100000.0;
+    }
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/LatestIDRRatesFetcher.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.LatestIDRRateResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.handler.GlobalExceptionHandler;
@@ -38,20 +39,19 @@ public class LatestIDRRatesFetcher implements IDRDataFetcher<LatestIDRRateRespon
 
         Map<String, Object> response = restTemplate.getForObject(latestUrl, Map.class);
 
-        if (response == null || !response.containsKey("rates")) {
-            throw new BadRequestException("Failed to fetch latest IDR rates");
+        if (response == null || !response.containsKey(Constant.RATES_KEY)) {
+            throw new BadRequestException(Constant.FAILED_FETCH_LATEST_IDR_RATES);
         }
 
-        Map<String, Object> rates = (Map<String, Object>) response.get("rates");
-        double rateUSD = ((Number) rates.get("USD")).doubleValue();
+        Map<String, Object> rates = (Map<String, Object>) response.get(Constant.RATES_KEY);
+        double rateUSD = ((Number) rates.get(Constant.USD)).doubleValue();
         double spreadFactor = calculateSpreadFactor(githubUsername);
-        log.info("spreadFactor : " + spreadFactor);
         double usdBuySpread = (1 / rateUSD) * (1 + spreadFactor);
 
-        Map<String, Double> mappedRates = Map.of("IDR", usdBuySpread);
+        Map<String, Double> mappedRates = Map.of(Constant.IDR, usdBuySpread);
 
         LatestIDRRateResponseDTO dto = new LatestIDRRateResponseDTO(
-                (String) response.getOrDefault("date", LocalDate.now().toString()),
+                (String) response.getOrDefault(Constant.DATE, LocalDate.now().toString()),
                 rateUSD,
                 usdBuySpread
         );

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.CurrenciesResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
@@ -24,20 +25,17 @@ public class SupportedCurrenciesFetcher implements IDRDataFetcher<CurrenciesResp
     @Override
     public List<CurrenciesResponseDTO> fetchData() {
         if (restTemplate == null) {
-            throw new BadRequestException("RestTemplate must be set before fetching data");
+            throw new BadRequestException(Constant.REST_TEMPLATE_NOT_SET);
         }
 
-        // Ambil data dari API eksternal
         Map<String, String> response = restTemplate.getForObject(currenciesUrl, Map.class);
 
         if (response == null) {
-            throw new BadRequestException("Failed to fetch supported currencies");
+            throw new BadRequestException(Constant.FAILED_FETCH_SUPPORTED_CURRENCIES);
         }
 
-        // Bungkus Map di dalam satu DTO
         CurrenciesResponseDTO dto = new CurrenciesResponseDTO(response);
 
-        // Kembalikan sebagai List dengan satu elemen
         return Collections.singletonList(dto);
     }
 }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
@@ -1,0 +1,48 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@Component("supported_currencies")
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    @Autowired
+    public RestTemplate restTemplate;
+
+    @Value("${external.frankfurter.currencies-url}")
+    public String currenciesUrl;
+
+    @Override
+    public List<Map<String, Object>> fetchData() {
+        if (restTemplate == null) {
+            throw new BadRequestException("RestTemplate must be set before fetching data");
+        }
+
+        Map<String, String> response = restTemplate.getForObject(currenciesUrl, Map.class);
+
+        if (response == null) {
+            throw new BadRequestException("Failed to fetch supported currencies");
+        }
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        response.forEach((code, name) -> {
+            Map<String, Object> record = new HashMap<>();
+            record.put("code", code);
+            record.put("name", name);
+            result.add(record);
+        });
+
+        return result;
+    }
+
+}

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy.impl;
 
+import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.CurrenciesResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,14 +8,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-
 @Component("supported_currencies")
-public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+public class SupportedCurrenciesFetcher implements IDRDataFetcher<CurrenciesResponseDTO> {
 
     @Autowired
     public RestTemplate restTemplate;
@@ -23,26 +22,22 @@ public class SupportedCurrenciesFetcher implements IDRDataFetcher {
     public String currenciesUrl;
 
     @Override
-    public List<Map<String, Object>> fetchData() {
+    public List<CurrenciesResponseDTO> fetchData() {
         if (restTemplate == null) {
             throw new BadRequestException("RestTemplate must be set before fetching data");
         }
 
+        // Ambil data dari API eksternal
         Map<String, String> response = restTemplate.getForObject(currenciesUrl, Map.class);
 
         if (response == null) {
             throw new BadRequestException("Failed to fetch supported currencies");
         }
 
-        List<Map<String, Object>> result = new ArrayList<>();
-        response.forEach((code, name) -> {
-            Map<String, Object> record = new HashMap<>();
-            record.put("code", code);
-            record.put("name", name);
-            result.add(record);
-        });
+        // Bungkus Map di dalam satu DTO
+        CurrenciesResponseDTO dto = new CurrenciesResponseDTO(response);
 
-        return result;
+        // Kembalikan sebagai List dengan satu elemen
+        return Collections.singletonList(dto);
     }
-
 }

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/impl/SupportedCurrenciesFetcher.java
@@ -24,9 +24,6 @@ public class SupportedCurrenciesFetcher implements IDRDataFetcher<CurrenciesResp
 
     @Override
     public List<CurrenciesResponseDTO> fetchData() {
-        if (restTemplate == null) {
-            throw new BadRequestException(Constant.REST_TEMPLATE_NOT_SET);
-        }
 
         Map<String, String> response = restTemplate.getForObject(currenciesUrl, Map.class);
 

--- a/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/util/DateUtils.java
+++ b/allo-bank-backend-test/src/main/java/id/tisnanda/allobank/allo_bank_backend_test/util/DateUtils.java
@@ -1,0 +1,14 @@
+package id.tisnanda.allobank.allo_bank_backend_test.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtils {
+
+    public static String formatLocalDateTime(LocalDateTime dateTime) {
+        if (dateTime == null) return null;
+
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return dateTime.format(outputFormatter);
+    }
+}

--- a/allo-bank-backend-test/src/main/resources/application.yaml
+++ b/allo-bank-backend-test/src/main/resources/application.yaml
@@ -8,9 +8,15 @@ spring:
 frankfurter:
   api:
     base-url: https://api.frankfurter.app
-    timeout: 5000 # dalam milidetik
+    timeout: 5000
     headers:
       Accept: application/json
+
+external:
+  frankfurter:
+    latest-url: "https://api.frankfurter.app/latest?base=IDR"
+    currencies-url: "https://api.frankfurter.app/currencies"
+    historical-url: "https://api.frankfurter.app/2024-01-01..2024-01-05?from=IDR&to=USD"
 
 resources:
   - latest_idr_rates
@@ -19,3 +25,12 @@ resources:
 
 spread:
   github-username: "tisnandanurhidayat"
+
+logging:
+  level:
+    root: INFO
+    id.tisnanda.allobank: INFO
+    org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver: ERROR
+
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"

--- a/allo-bank-backend-test/src/main/resources/application.yaml
+++ b/allo-bank-backend-test/src/main/resources/application.yaml
@@ -1,0 +1,21 @@
+server:
+  port: 8089
+
+spring:
+  application:
+    name: allo-bank-backend-test
+
+frankfurter:
+  api:
+    base-url: https://api.frankfurter.app
+    timeout: 5000 # dalam milidetik
+    headers:
+      Accept: application/json
+
+resources:
+  - latest_idr_rates
+  - historical_idr_usd
+  - supported_currencies
+
+spread:
+  github-username: "tisnandanurhidayat"

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/AlloBankBackendTestApplicationTests.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/AlloBankBackendTestApplicationTests.java
@@ -1,0 +1,13 @@
+package id.tisnanda.allobank.allo_bank_backend_test;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AlloBankBackendTestApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandlerTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,56 @@
+package id.tisnanda.allobank.allo_bank_backend_test.exception.handler;
+
+import id.tisnanda.allobank.allo_bank_backend_test.dto.ErrorResponse;
+import id.tisnanda.allobank.allo_bank_backend_test.exception.AlloBankException;
+import id.tisnanda.allobank.allo_bank_backend_test.exception.ErrorCodes;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ControllerAdvice
+public class GlobalExceptionHandlerTest {
+//    private GlobalExceptionHandler handler;
+//    private HttpServletRequest request;
+//
+//    @BeforeEach
+//    void setUp() {
+//        handler = new GlobalExceptionHandler();
+//        request = mock(HttpServletRequest.class);
+//        when(request.getRequestURI()).thenReturn("/api/test");
+//    }
+//
+//    @Test
+//    void testHandleAlloBankException() {
+//        AlloBankException ex = new AlloBankException("Data not found", ErrorCodes.RESOURCE_NOT_FOUND);
+//
+//        ResponseEntity<ErrorResponse> responseEntity = handler.handleAlloBankException(ex, request);
+//        ErrorResponse response = responseEntity.getBody();
+//
+//        Assertions.assertNotNull(response);
+//        Assertions.assertEquals("404", response.getCode());
+//        Assertions.assertEquals("Data not found", response.getMessage());
+//        Assertions.assertEquals("RESOURCE_NOT_FOUND", response.getError());
+//        Assertions.assertEquals("/api/test", response.getPath());
+//        Assertions.assertNotNull(response.getTimestamp());
+//    }
+//
+//    @Test
+//    void testHandleUnexpectedException() {
+//        Exception ex = new RuntimeException("Internal server error");
+//
+//        ResponseEntity<ErrorResponse> responseEntity = handler.handleUnexpectedException(ex, request);
+//        ErrorResponse response = responseEntity.getBody();
+//
+//        Assertions.assertEquals("500", response.getCode());
+//        Assertions.assertEquals("Internal server error", response.getMessage());
+//        Assertions.assertEquals("RuntimeException", response.getError());
+//        Assertions.assertEquals("/api/test", response.getPath());
+//        Assertions.assertNotNull(response.getTimestamp());
+//    }
+}

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandlerTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.exception.handler;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.ErrorResponse;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.AlloBankException;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.ErrorCodes;
@@ -22,35 +23,35 @@ public class GlobalExceptionHandlerTest {
     void setUp() {
         handler = new GlobalExceptionHandler();
         request = mock(HttpServletRequest.class);
-        when(request.getRequestURI()).thenReturn("/api/test");
+        when(request.getRequestURI()).thenReturn(Constant.TEST_API_URI);
     }
 
     @Test
     void testHandleAlloBankException() {
-        AlloBankException ex = new AlloBankException("Data not found", ErrorCodes.RESOURCE_NOT_FOUND);
+        AlloBankException ex = new AlloBankException(Constant.DATA_NOT_FOUND, ErrorCodes.RESOURCE_NOT_FOUND);
 
         ResponseEntity<ErrorResponse> responseEntity = handler.handleAlloBankException(ex, request);
         ErrorResponse response = responseEntity.getBody();
 
         Assertions.assertNotNull(response);
-        Assertions.assertEquals("404", response.getCode());
-        Assertions.assertEquals("Data not found", response.getMessage());
-        Assertions.assertEquals("RESOURCE_NOT_FOUND", response.getError());
-        Assertions.assertEquals("/api/test", response.getPath());
+        Assertions.assertEquals(Constant.RESOURCE_NOT_FOUND_CODE, response.getCode());
+        Assertions.assertEquals(Constant.DATA_NOT_FOUND, response.getMessage());
+        Assertions.assertEquals(Constant.RESOURCE_NOT_FOUND, response.getError());
+        Assertions.assertEquals(Constant.TEST_API_URI, response.getPath());
         Assertions.assertNotNull(response.getTimestamp());
     }
 
     @Test
     void testHandleUnexpectedException() {
-        Exception ex = new RuntimeException("Internal server error");
+        Exception ex = new RuntimeException(Constant.INTERNAL_SERVER_ERROR);
 
         ResponseEntity<ErrorResponse> responseEntity = handler.handleUnexpectedException(ex, request);
         ErrorResponse response = responseEntity.getBody();
 
-        Assertions.assertEquals("500", response.getCode());
-        Assertions.assertEquals("Internal server error", response.getMessage());
-        Assertions.assertEquals("RuntimeException", response.getError());
-        Assertions.assertEquals("/api/test", response.getPath());
+        Assertions.assertEquals(Constant.INTERNAL_SERVER_ERROR_CODE, response.getCode());
+        Assertions.assertEquals(Constant.INTERNAL_SERVER_ERROR, response.getMessage());
+        Assertions.assertEquals(Constant.RUNTIME_EXCEPTION, response.getError());
+        Assertions.assertEquals(Constant.TEST_API_URI, response.getPath());
         Assertions.assertNotNull(response.getTimestamp());
     }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandlerTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/exception/handler/GlobalExceptionHandlerTest.java
@@ -15,42 +15,42 @@ import static org.mockito.Mockito.when;
 
 @ControllerAdvice
 public class GlobalExceptionHandlerTest {
-//    private GlobalExceptionHandler handler;
-//    private HttpServletRequest request;
-//
-//    @BeforeEach
-//    void setUp() {
-//        handler = new GlobalExceptionHandler();
-//        request = mock(HttpServletRequest.class);
-//        when(request.getRequestURI()).thenReturn("/api/test");
-//    }
-//
-//    @Test
-//    void testHandleAlloBankException() {
-//        AlloBankException ex = new AlloBankException("Data not found", ErrorCodes.RESOURCE_NOT_FOUND);
-//
-//        ResponseEntity<ErrorResponse> responseEntity = handler.handleAlloBankException(ex, request);
-//        ErrorResponse response = responseEntity.getBody();
-//
-//        Assertions.assertNotNull(response);
-//        Assertions.assertEquals("404", response.getCode());
-//        Assertions.assertEquals("Data not found", response.getMessage());
-//        Assertions.assertEquals("RESOURCE_NOT_FOUND", response.getError());
-//        Assertions.assertEquals("/api/test", response.getPath());
-//        Assertions.assertNotNull(response.getTimestamp());
-//    }
-//
-//    @Test
-//    void testHandleUnexpectedException() {
-//        Exception ex = new RuntimeException("Internal server error");
-//
-//        ResponseEntity<ErrorResponse> responseEntity = handler.handleUnexpectedException(ex, request);
-//        ErrorResponse response = responseEntity.getBody();
-//
-//        Assertions.assertEquals("500", response.getCode());
-//        Assertions.assertEquals("Internal server error", response.getMessage());
-//        Assertions.assertEquals("RuntimeException", response.getError());
-//        Assertions.assertEquals("/api/test", response.getPath());
-//        Assertions.assertNotNull(response.getTimestamp());
-//    }
+    private GlobalExceptionHandler handler;
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalExceptionHandler();
+        request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/api/test");
+    }
+
+    @Test
+    void testHandleAlloBankException() {
+        AlloBankException ex = new AlloBankException("Data not found", ErrorCodes.RESOURCE_NOT_FOUND);
+
+        ResponseEntity<ErrorResponse> responseEntity = handler.handleAlloBankException(ex, request);
+        ErrorResponse response = responseEntity.getBody();
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals("404", response.getCode());
+        Assertions.assertEquals("Data not found", response.getMessage());
+        Assertions.assertEquals("RESOURCE_NOT_FOUND", response.getError());
+        Assertions.assertEquals("/api/test", response.getPath());
+        Assertions.assertNotNull(response.getTimestamp());
+    }
+
+    @Test
+    void testHandleUnexpectedException() {
+        Exception ex = new RuntimeException("Internal server error");
+
+        ResponseEntity<ErrorResponse> responseEntity = handler.handleUnexpectedException(ex, request);
+        ErrorResponse response = responseEntity.getBody();
+
+        Assertions.assertEquals("500", response.getCode());
+        Assertions.assertEquals("Internal server error", response.getMessage());
+        Assertions.assertEquals("RuntimeException", response.getError());
+        Assertions.assertEquals("/api/test", response.getPath());
+        Assertions.assertNotNull(response.getTimestamp());
+    }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoaderTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoaderTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.runner;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.service.IDRFinanceService;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,24 +23,24 @@ class IDRDataLoaderTest {
         financeService = mock(IDRFinanceService.class);
         fetcherMock = mock(IDRDataFetcher.class);
 
-        Map<String, IDRDataFetcher> fetchers = Map.of("historical_idr_usd", fetcherMock);
+        Map<String, IDRDataFetcher> fetchers = Map.of(Constant.HISTORICAL_IDR_USD, fetcherMock);
         loader = new IDRDataLoader(financeService, fetchers);
     }
 
     @Test
     void testRun_success() throws Exception {
-        List<Map<String, Object>> mockData = Collections.singletonList(Map.of("USD", 0.00006));
+        List<Map<String, Object>> mockData = Collections.singletonList(Map.of(Constant.USD, 0.00006));
         when(fetcherMock.fetchData()).thenReturn(mockData);
 
         loader.run(null);
 
         verify(fetcherMock, times(1)).fetchData();
-        verify(financeService, times(1)).setData("historical_idr_usd", mockData);
+        verify(financeService, times(1)).setData(Constant.HISTORICAL_IDR_USD, mockData);
     }
 
     @Test
     void testRun_fetcherThrows_exception() throws Exception {
-        when(fetcherMock.fetchData()).thenThrow(new RuntimeException("API failed"));
+        when(fetcherMock.fetchData()).thenThrow(new RuntimeException(Constant.API_FAILED));
 
         try {
             loader.run(null);

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoaderTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/runner/IDRDataLoaderTest.java
@@ -1,0 +1,51 @@
+package id.tisnanda.allobank.allo_bank_backend_test.runner;
+
+import id.tisnanda.allobank.allo_bank_backend_test.service.IDRFinanceService;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.IDRDataFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+class IDRDataLoaderTest {
+
+    private IDRFinanceService financeService;
+    private IDRDataFetcher fetcherMock;
+    private IDRDataLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        financeService = mock(IDRFinanceService.class);
+        fetcherMock = mock(IDRDataFetcher.class);
+
+        Map<String, IDRDataFetcher> fetchers = Map.of("historical_idr_usd", fetcherMock);
+        loader = new IDRDataLoader(financeService, fetchers);
+    }
+
+    @Test
+    void testRun_success() throws Exception {
+        List<Map<String, Object>> mockData = Collections.singletonList(Map.of("USD", 0.00006));
+        when(fetcherMock.fetchData()).thenReturn(mockData);
+
+        loader.run(null);
+
+        verify(fetcherMock, times(1)).fetchData();
+        verify(financeService, times(1)).setData("historical_idr_usd", mockData);
+    }
+
+    @Test
+    void testRun_fetcherThrows_exception() throws Exception {
+        when(fetcherMock.fetchData()).thenThrow(new RuntimeException("API failed"));
+
+        try {
+            loader.run(null);
+        } catch (IllegalStateException ignored) {}
+
+        verify(fetcherMock, times(1)).fetchData();
+        verify(financeService, never()).setData(anyString(), any());
+    }
+}

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.HistoricalIDRUSDResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.HistoricalIDRUSDFetcher;
@@ -21,31 +22,30 @@ class HistoricalIDRUSDFetcherTest {
 
     private HistoricalIDRUSDFetcher fetcher;
     private RestTemplate restTemplate;
-    private String mockUrl = "http://mock-url";
 
     @BeforeEach
     void setUp() {
         restTemplate = mock(RestTemplate.class);
         fetcher = new HistoricalIDRUSDFetcher();
         fetcher.restTemplate = restTemplate; // set manual
-        fetcher.historicalUrl = mockUrl;     // set manual
+        fetcher.historicalUrl = Constant.MOCK_URL;     // set manual
     }
 
     @Test
     void testFetchData_withMockedApi() {
         Map<String, Object> usdRate1 = new HashMap<>();
-        usdRate1.put("USD", 15000.0);
+        usdRate1.put(Constant.USD, Constant.RATE_15000);
         Map<String, Object> usdRate2 = new HashMap<>();
-        usdRate2.put("USD", 15100.0);
+        usdRate2.put(Constant.USD, Constant.RATE_15100);
 
         Map<String, Object> rates = new HashMap<>();
-        rates.put("2025-12-05", usdRate1);
-        rates.put("2025-12-06", usdRate2);
+        rates.put(Constant.DATE_2025_12_05, usdRate1);
+        rates.put(Constant.DATE_2025_12_06, usdRate2);
 
         Map<String, Object> response = new HashMap<>();
-        response.put("rates", rates);
+        response.put(Constant.RATES_KEY, rates);
 
-        when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+        when(restTemplate.getForObject(Constant.MOCK_URL, Map.class)).thenReturn(response);
 
         List<HistoricalIDRUSDResponseDTO> result = fetcher.fetchData();
 
@@ -54,10 +54,10 @@ class HistoricalIDRUSDFetcherTest {
         HistoricalIDRUSDResponseDTO first = result.get(0);
         HistoricalIDRUSDResponseDTO second = result.get(1);
 
-        assertEquals("2025-12-05", first.getDate());
-        assertEquals(15000.0, first.getUsd());
-        assertEquals("2025-12-06", second.getDate());
-        assertEquals(15100.0, second.getUsd());
+        assertEquals(Constant.DATE_2025_12_05, first.getDate());
+        assertEquals(Constant.RATE_15000, first.getUsd());
+        assertEquals(Constant.DATE_2025_12_06, second.getDate());
+        assertEquals(Constant.RATE_15100, second.getUsd());
     }
 
     @Test
@@ -65,15 +65,15 @@ class HistoricalIDRUSDFetcherTest {
         fetcher.restTemplate = null;
 
         BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
+        assertEquals(Constant.REST_TEMPLATE_NOT_SET, exception.getMessage());
     }
 
     @Test
     void testFetchData_whenRatesMissing_shouldThrowException() {
         Map<String, Object> response = new HashMap<>();
-        when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+        when(restTemplate.getForObject(Constant.MOCK_URL, Map.class)).thenReturn(response);
 
         BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals("Failed to fetch historical IDR->USD rates", exception.getMessage());
+        assertEquals(Constant.FAILED_FETCH_HISTORICAL_IDR_USD_RATES, exception.getMessage());
     }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
+import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.HistoricalIDRUSDResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.HistoricalIDRUSDFetcher;
 import org.jboss.logging.Logger;
@@ -11,10 +12,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class HistoricalIDRUSDFetcherTest {
 
@@ -35,9 +34,9 @@ class HistoricalIDRUSDFetcherTest {
     @Test
     void testFetchData_withMockedApi() {
         Map<String, Object> usdRate1 = new HashMap<>();
-        usdRate1.put("USD", 15000);
+        usdRate1.put("USD", 15000.0);
         Map<String, Object> usdRate2 = new HashMap<>();
-        usdRate2.put("USD", 15100);
+        usdRate2.put("USD", 15100.0);
 
         Map<String, Object> rates = new HashMap<>();
         rates.put("2025-12-05", usdRate1);
@@ -48,20 +47,24 @@ class HistoricalIDRUSDFetcherTest {
 
         when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
 
-        List<Map<String, Object>> result = fetcher.fetchData();
+        List<HistoricalIDRUSDResponseDTO> result = fetcher.fetchData();
 
         assertEquals(2, result.size());
-        assertEquals("2025-12-05", result.get(0).get("date"));
-        assertEquals(15000, result.get(0).get("USD"));
-        assertEquals("2025-12-06", result.get(1).get("date"));
-        assertEquals(15100, result.get(1).get("USD"));
+
+        HistoricalIDRUSDResponseDTO first = result.get(0);
+        HistoricalIDRUSDResponseDTO second = result.get(1);
+
+        assertEquals("2025-12-05", first.getDate());
+        assertEquals(15000.0, first.getUsd());
+        assertEquals("2025-12-06", second.getDate());
+        assertEquals(15100.0, second.getUsd());
     }
 
     @Test
     void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
         fetcher.restTemplate = null;
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
+        BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
         assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
     }
 
@@ -70,7 +73,7 @@ class HistoricalIDRUSDFetcherTest {
         Map<String, Object> response = new HashMap<>();
         when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
+        BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
         assertEquals("Failed to fetch historical IDR->USD rates", exception.getMessage());
     }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
@@ -1,0 +1,76 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy;
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.HistoricalIDRUSDFetcher;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HistoricalIDRUSDFetcherTest {
+
+    private static final Logger log = Logger.getLogger(HistoricalIDRUSDFetcherTest.class);
+
+    private HistoricalIDRUSDFetcher fetcher;
+    private RestTemplate restTemplate;
+    private String mockUrl = "http://mock-url";
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        fetcher = new HistoricalIDRUSDFetcher();
+        fetcher.restTemplate = restTemplate; // set manual
+        fetcher.historicalUrl = mockUrl;     // set manual
+    }
+
+    @Test
+    void testFetchData_withMockedApi() {
+        Map<String, Object> usdRate1 = new HashMap<>();
+        usdRate1.put("USD", 15000);
+        Map<String, Object> usdRate2 = new HashMap<>();
+        usdRate2.put("USD", 15100);
+
+        Map<String, Object> rates = new HashMap<>();
+        rates.put("2025-12-05", usdRate1);
+        rates.put("2025-12-06", usdRate2);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("rates", rates);
+
+        when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+
+        List<Map<String, Object>> result = fetcher.fetchData();
+
+        assertEquals(2, result.size());
+        assertEquals("2025-12-05", result.get(0).get("date"));
+        assertEquals(15000, result.get(0).get("USD"));
+        assertEquals("2025-12-06", result.get(1).get("date"));
+        assertEquals(15100, result.get(1).get("USD"));
+    }
+
+    @Test
+    void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
+        fetcher.restTemplate = null;
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
+        assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
+    }
+
+    @Test
+    void testFetchData_whenRatesMissing_shouldThrowException() {
+        Map<String, Object> response = new HashMap<>();
+        when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
+        assertEquals("Failed to fetch historical IDR->USD rates", exception.getMessage());
+    }
+}

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/HistoricalIDRUSDFetcherTest.java
@@ -61,14 +61,6 @@ class HistoricalIDRUSDFetcherTest {
     }
 
     @Test
-    void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
-        fetcher.restTemplate = null;
-
-        BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals(Constant.REST_TEMPLATE_NOT_SET, exception.getMessage());
-    }
-
-    @Test
     void testFetchData_whenRatesMissing_shouldThrowException() {
         Map<String, Object> response = new HashMap<>();
         when(restTemplate.getForObject(Constant.MOCK_URL, Map.class)).thenReturn(response);

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.LatestIDRRateResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.LatestIDRRatesFetcher;
@@ -29,23 +30,21 @@ class LatestIDRRatesFetcherTest {
     @InjectMocks
     private LatestIDRRatesFetcher fetcher;
 
-    private final String mockUrl = "/latest?base=IDR";
-
     @BeforeEach
     void setUp() {
-        fetcher.setLatestUrl(mockUrl);
-        fetcher.setGithubUsername("tisnandanurhidayat");
+        fetcher.setLatestUrl(Constant.MOCK_URL_LATEST);
+        fetcher.setGithubUsername(Constant.TISNANDA_NUR_HIDAYAT);
     }
 
     @Test
     void testFetchData_withMockedApi_returnsDto() {
         Map<String, Object> mockedResponse = new HashMap<>();
-        mockedResponse.put("base", "IDR");
-        mockedResponse.put("date", "2025-12-07");
+        mockedResponse.put(Constant.BASE, Constant.IDR);
+        mockedResponse.put(Constant.DATE, Constant.DATE_2025_12_07);
 
         Map<String, Object> rates = new HashMap<>();
-        rates.put("USD", 15000.0);
-        mockedResponse.put("rates", rates);
+        rates.put(Constant.USD, Constant.RATE_15000);
+        mockedResponse.put(Constant.RATES_KEY, rates);
 
         when(restTemplate.getForObject(fetcher.getLatestUrl(), Map.class))
                 .thenReturn(mockedResponse);
@@ -56,10 +55,10 @@ class LatestIDRRatesFetcherTest {
 
         LatestIDRRateResponseDTO dto = result.get(0);
 
-        assertEquals("2025-12-07", dto.getDate());
-        assertEquals(15000.0, dto.getUsd());
+        assertEquals(Constant.DATE_2025_12_07, dto.getDate());
+        assertEquals(Constant.RATE_15000, dto.getUsd());
 
-        double expectedSpread = (1 / 15000.0) * (1 + fetcher.calculateSpreadFactor("tisnandanurhidayat"));
+        double expectedSpread = (1 / Constant.RATE_15000) * (1 + fetcher.calculateSpreadFactor(Constant.TISNANDA_NUR_HIDAYAT));
         assertEquals(expectedSpread, dto.getUsdBuySpreedIDR(), 1e-6);
     }
 
@@ -70,15 +69,15 @@ class LatestIDRRatesFetcherTest {
         when(restTemplate.getForObject(fetcher.getLatestUrl(), Map.class)).thenReturn(response);
 
         BadRequestException ex = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals("Failed to fetch latest IDR rates", ex.getMessage());
+        assertEquals(Constant.FAILED_FETCH_LATEST_IDR_RATES, ex.getMessage());
     }
 
     @Test
     void testFetchData_whenRatesMissing_shouldThrowException() {
         Map<String, Object> response = Collections.emptyMap(); // rates missing
-        when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+        when(restTemplate.getForObject(Constant.MOCK_URL_LATEST, Map.class)).thenReturn(response);
 
         BadRequestException ex = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals("Failed to fetch latest IDR rates", ex.getMessage());
+        assertEquals(Constant.FAILED_FETCH_LATEST_IDR_RATES, ex.getMessage());
     }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
@@ -57,10 +57,10 @@ class LatestIDRRatesFetcherTest {
         LatestIDRRateResponseDTO dto = result.get(0);
 
         assertEquals("2025-12-07", dto.getDate());
-        assertEquals(15000.0, dto.getUSD());
+        assertEquals(15000.0, dto.getUsd());
 
         double expectedSpread = (1 / 15000.0) * (1 + fetcher.calculateSpreadFactor("tisnandanurhidayat"));
-        assertEquals(expectedSpread, dto.getUSD_BuySpread_IDR(), 1e-6);
+        assertEquals(expectedSpread, dto.getUsdBuySpreedIDR(), 1e-6);
     }
 
     @Test

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
@@ -1,78 +1,84 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
+import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.LatestIDRRateResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.LatestIDRRatesFetcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-public class LatestIDRRatesFetcherTest {
+class LatestIDRRatesFetcherTest {
 
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
     private LatestIDRRatesFetcher fetcher;
-    private RestTemplate mockRestTemplate;
-    private String mockUrl = "/latest?base=IDR";
+
+    private final String mockUrl = "/latest?base=IDR";
 
     @BeforeEach
     void setUp() {
-        mockRestTemplate = mock(RestTemplate.class);
-        fetcher = new LatestIDRRatesFetcher();
-        fetcher.restTemplate = mockRestTemplate; // set manual
-        fetcher.latestUrl = mockUrl;             // set manual
+        fetcher.setLatestUrl(mockUrl);
         fetcher.setGithubUsername("tisnandanurhidayat");
     }
 
     @Test
-    void testFetchData_withMockedApi() {
-        // Dummy API response
+    void testFetchData_withMockedApi_returnsDto() {
+        Map<String, Object> mockedResponse = new HashMap<>();
+        mockedResponse.put("base", "IDR");
+        mockedResponse.put("date", "2025-12-07");
+
         Map<String, Object> rates = new HashMap<>();
-        rates.put("USD", 6.0E-5);
-        rates.put("EUR", 5.2E-5);
+        rates.put("USD", 15000.0);
+        mockedResponse.put("rates", rates);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("rates", rates);
+        when(restTemplate.getForObject(fetcher.getLatestUrl(), Map.class))
+                .thenReturn(mockedResponse);
 
-        // Stub RestTemplate
-        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+        List<LatestIDRRateResponseDTO> result = fetcher.fetchData();
 
-        List<Map<String, Object>> result = fetcher.fetchData();
-
-        assertNotNull(result);
         assertEquals(1, result.size());
 
-        Map<String, Object> record = result.get(0);
-        assertTrue(record.containsKey("USD_BuySpread_IDR"));
-        double usdBuySpread = ((Number) record.get("USD_BuySpread_IDR")).doubleValue();
-        assertTrue(usdBuySpread > 0);
+        LatestIDRRateResponseDTO dto = result.get(0);
+
+        assertEquals("2025-12-07", dto.getDate());
+        assertEquals(15000.0, dto.getUSD());
+
+        double expectedSpread = (1 / 15000.0) * (1 + fetcher.calculateSpreadFactor("tisnandanurhidayat"));
+        assertEquals(expectedSpread, dto.getUSD_BuySpread_IDR(), 1e-6);
     }
 
     @Test
     void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
-        fetcher.restTemplate = null;
+        Map<String, Object> response = Collections.emptyMap();
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
-        assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
+        when(restTemplate.getForObject(fetcher.getLatestUrl(), Map.class)).thenReturn(response);
+
+        BadRequestException ex = assertThrows(BadRequestException.class, fetcher::fetchData);
+        assertEquals("Failed to fetch latest IDR rates", ex.getMessage());
     }
 
     @Test
     void testFetchData_whenRatesMissing_shouldThrowException() {
-        Map<String, Object> response = new HashMap<>();
-        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+        Map<String, Object> response = Collections.emptyMap(); // rates missing
+        when(restTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
 
-        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
-        assertEquals("Failed to fetch latest IDR rates", exception.getMessage());
+        BadRequestException ex = assertThrows(BadRequestException.class, fetcher::fetchData);
+        assertEquals("Failed to fetch latest IDR rates", ex.getMessage());
     }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/LatestIDRRatesFetcherTest.java
@@ -1,0 +1,78 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy;
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.LatestIDRRatesFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class LatestIDRRatesFetcherTest {
+
+    private LatestIDRRatesFetcher fetcher;
+    private RestTemplate mockRestTemplate;
+    private String mockUrl = "/latest?base=IDR";
+
+    @BeforeEach
+    void setUp() {
+        mockRestTemplate = mock(RestTemplate.class);
+        fetcher = new LatestIDRRatesFetcher();
+        fetcher.restTemplate = mockRestTemplate; // set manual
+        fetcher.latestUrl = mockUrl;             // set manual
+        fetcher.setGithubUsername("tisnandanurhidayat");
+    }
+
+    @Test
+    void testFetchData_withMockedApi() {
+        // Dummy API response
+        Map<String, Object> rates = new HashMap<>();
+        rates.put("USD", 6.0E-5);
+        rates.put("EUR", 5.2E-5);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("rates", rates);
+
+        // Stub RestTemplate
+        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+
+        List<Map<String, Object>> result = fetcher.fetchData();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        Map<String, Object> record = result.get(0);
+        assertTrue(record.containsKey("USD_BuySpread_IDR"));
+        double usdBuySpread = ((Number) record.get("USD_BuySpread_IDR")).doubleValue();
+        assertTrue(usdBuySpread > 0);
+    }
+
+    @Test
+    void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
+        fetcher.restTemplate = null;
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
+        assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
+    }
+
+    @Test
+    void testFetchData_whenRatesMissing_shouldThrowException() {
+        Map<String, Object> response = new HashMap<>();
+        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> fetcher.fetchData());
+        assertEquals("Failed to fetch latest IDR rates", exception.getMessage());
+    }
+}

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
+import id.tisnanda.allobank.allo_bank_backend_test.constant.Constant;
 import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.CurrenciesResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.SupportedCurrenciesFetcher;
@@ -18,24 +19,24 @@ class SupportedCurrenciesFetcherTest {
 
     private SupportedCurrenciesFetcher fetcher;
     private RestTemplate mockRestTemplate;
-    private String mockUrl = "http://mock-currencies-url";
+//    private String mockUrl = "http://mock-currencies-url";
 
     @BeforeEach
     void setUp() {
         mockRestTemplate = mock(RestTemplate.class);
         fetcher = new SupportedCurrenciesFetcher();
         fetcher.restTemplate = mockRestTemplate;
-        fetcher.currenciesUrl = mockUrl;
+        fetcher.currenciesUrl = Constant.MOCK_CURRENCIES_URL;
     }
 
     @Test
     void testFetchData_withMockedApi() {
         Map<String, String> response = new HashMap<>();
-        response.put("USD", "United States Dollar");
-        response.put("EUR", "Euro");
-        response.put("JPY", "Japanese Yen");
+        response.put(Constant.USD_CODE, Constant.USD_NAME);
+        response.put(Constant.EUR_CODE, Constant.EUR_NAME);
+        response.put(Constant.JPY_CODE, Constant.JPY_NAME);
 
-        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+        when(mockRestTemplate.getForObject(Constant.MOCK_CURRENCIES_URL, Map.class)).thenReturn(response);
 
         List<CurrenciesResponseDTO> result = fetcher.fetchData();
 
@@ -46,8 +47,8 @@ class SupportedCurrenciesFetcherTest {
         Map<String, String> currencies = dto.getCurrencies();
 
         assertEquals(3, currencies.size());
-        assertTrue(currencies.containsKey("USD"));
-        assertEquals("United States Dollar", currencies.get("USD"));
+        assertTrue(currencies.containsKey(Constant.USD));
+        assertEquals(Constant.USD_NAME, currencies.get(Constant.USD));
     }
 
     @Test
@@ -55,14 +56,14 @@ class SupportedCurrenciesFetcherTest {
         fetcher.restTemplate = null;
 
         BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
+        assertEquals(Constant.REST_TEMPLATE_NOT_SET, exception.getMessage());
     }
 
     @Test
     void testFetchData_whenResponseNull_shouldThrowException() {
-        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(null);
+        when(mockRestTemplate.getForObject(Constant.MOCK_CURRENCIES_URL, Map.class)).thenReturn(null);
 
         BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals("Failed to fetch supported currencies", exception.getMessage());
+        assertEquals(Constant.FAILED_FETCH_SUPPORTED_CURRENCIES, exception.getMessage());
     }
 }

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,64 @@
+package id.tisnanda.allobank.allo_bank_backend_test.strategy;
+
+import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
+import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.SupportedCurrenciesFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SupportedCurrenciesFetcherTest {
+
+    private SupportedCurrenciesFetcher fetcher;
+    private RestTemplate mockRestTemplate;
+    private String mockUrl = "http://mock-currencies-url";
+
+    @BeforeEach
+    void setUp() {
+        mockRestTemplate = mock(RestTemplate.class);
+        fetcher = new SupportedCurrenciesFetcher();
+        fetcher.restTemplate = mockRestTemplate;  // set manual
+        fetcher.currenciesUrl = mockUrl;          // set manual
+    }
+
+    @Test
+    void testFetchData_withMockedApi() {
+        Map<String, String> response = new HashMap<>();
+        response.put("USD", "United States Dollar");
+        response.put("EUR", "Euro");
+        response.put("JPY", "Japanese Yen");
+
+        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
+
+        List<Map<String, Object>> result = fetcher.fetchData();
+
+        assertEquals(3, result.size());
+
+        // Pastikan salah satu currency ada
+        Map<String, Object> first = result.get(0);
+        assertTrue(first.containsKey("code"));
+        assertTrue(first.containsKey("name"));
+    }
+
+    @Test
+    void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
+        fetcher.restTemplate = null;
+
+        BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
+        assertEquals("RestTemplate must be set before fetching data", exception.getMessage());
+    }
+
+    @Test
+    void testFetchData_whenResponseNull_shouldThrowException() {
+        when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(null);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
+        assertEquals("Failed to fetch supported currencies", exception.getMessage());
+    }
+}

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
@@ -19,7 +19,6 @@ class SupportedCurrenciesFetcherTest {
 
     private SupportedCurrenciesFetcher fetcher;
     private RestTemplate mockRestTemplate;
-//    private String mockUrl = "http://mock-currencies-url";
 
     @BeforeEach
     void setUp() {

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
@@ -51,14 +51,6 @@ class SupportedCurrenciesFetcherTest {
     }
 
     @Test
-    void testFetchData_whenRestTemplateIsNull_shouldThrowException() {
-        fetcher.restTemplate = null;
-
-        BadRequestException exception = assertThrows(BadRequestException.class, fetcher::fetchData);
-        assertEquals(Constant.REST_TEMPLATE_NOT_SET, exception.getMessage());
-    }
-
-    @Test
     void testFetchData_whenResponseNull_shouldThrowException() {
         when(mockRestTemplate.getForObject(Constant.MOCK_CURRENCIES_URL, Map.class)).thenReturn(null);
 

--- a/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
+++ b/allo-bank-backend-test/src/test/java/id/tisnanda/allobank/allo_bank_backend_test/strategy/SupportedCurrenciesFetcherTest.java
@@ -1,5 +1,6 @@
 package id.tisnanda.allobank.allo_bank_backend_test.strategy;
 
+import id.tisnanda.allobank.allo_bank_backend_test.dto.strategy.CurrenciesResponseDTO;
 import id.tisnanda.allobank.allo_bank_backend_test.exception.BadRequestException;
 import id.tisnanda.allobank.allo_bank_backend_test.strategy.impl.SupportedCurrenciesFetcher;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,8 +24,8 @@ class SupportedCurrenciesFetcherTest {
     void setUp() {
         mockRestTemplate = mock(RestTemplate.class);
         fetcher = new SupportedCurrenciesFetcher();
-        fetcher.restTemplate = mockRestTemplate;  // set manual
-        fetcher.currenciesUrl = mockUrl;          // set manual
+        fetcher.restTemplate = mockRestTemplate;
+        fetcher.currenciesUrl = mockUrl;
     }
 
     @Test
@@ -36,14 +37,17 @@ class SupportedCurrenciesFetcherTest {
 
         when(mockRestTemplate.getForObject(mockUrl, Map.class)).thenReturn(response);
 
-        List<Map<String, Object>> result = fetcher.fetchData();
+        List<CurrenciesResponseDTO> result = fetcher.fetchData();
 
-        assertEquals(3, result.size());
+        // Hanya satu DTO karena kita bungkus Map di DTO
+        assertEquals(1, result.size());
 
-        // Pastikan salah satu currency ada
-        Map<String, Object> first = result.get(0);
-        assertTrue(first.containsKey("code"));
-        assertTrue(first.containsKey("name"));
+        CurrenciesResponseDTO dto = result.get(0);
+        Map<String, String> currencies = dto.getCurrencies();
+
+        assertEquals(3, currencies.size());
+        assertTrue(currencies.containsKey("USD"));
+        assertEquals("United States Dollar", currencies.get("USD"));
     }
 
     @Test


### PR DESCRIPTION
1.Summary

PR ini berisi implementasi lengkap aplikasi Spring Boot untuk mengagregasi data kurs IDR dari Frankfurter API menggunakan arsitektur yang scalable dan production-grade.

Aplikasi menyediakan satu endpoint utama:

GET /api/finance/data/{resourceType}

Dengan tiga jenis resource:

- latest_idr_rates
- historical_idr_usd
- supported_currencies


Semua data diambil sekali saat startup via ApplicationRunner, disimpan pada in-memory storage yang immutable dan thread-safe, lalu disajikan via Strategy Pattern.

Fitur utama:

- Strategy Pattern untuk manajemen resource
- FactoryBean untuk membuat API client (RestTemplate/WebClient)
- ApplicationRunner untuk preload data
- Perhitungan USD_BuySpread_IDR spesifik berdasarkan GitHub username
- Unit Test & Integration Test lengkap
- Response wrapper dengan Global Response Filter

2. GitHub Username & Spread Factor

GitHub Username : tisnandanurhidayat
ASCII Sum         : 1931
Spread Factor   : (1931 % 1000) / 100000 = 0.00931
USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)

3. How to Run

- ./mvnw clean install
- ./mvnw spring-boot:run

Requirements:

- Java 17+
- Maven 3.5.8+
- Internet connection (hanya saat initial fetch)

4. Endpoint Usage

Latest IDR Rates : curl http://localhost:8089/api/finance/data/latest_idr_rates
Historical IDR → USD : curl http://localhost:8089/api/finance/data/historical_idr_usd
Supported Currencies : curl http://localhost:8089/api/finance/data/supported_currencies


Semua response succes dibungkus GlobalResponseFilter: 

{
  "code": "200",
  "message": "Success",
  "resource": "ALBS",
  "data": [...]
}

Semua response Error di bungkus GlobalExceptionHandler

{
    "code": "404",
    "message": "latest_idr_ratess",
    "error": "RESOURCE_NOT_FOUND",
    "path": "/api/finance/data/latest_idr_ratess",
    "timestamp": "2025-12-07 16:54:09"
}

Semua logging RestTemplate akan tercatat di RestClientLoggingMiddleware ketika Applikasi runtime tidak pada saat startup .

5. Architectural Rationale

A. Strategy Pattern Justification
Strategy Pattern digunakan untuk memisahkan logic dari 3 jenis resource:

-latest_idr_rates
-historical_idr_usd
-supported_currencies

Alasan Teknis : 

- Menghindari if/else atau switch panjang di controller
- Low coupling, high cohesion
- Mudah menambah resource baru tanpa mengubah logic existing
- Unit test per-strategy menjadi sangat mudah
- Controller hanya melakukan lookup berdasarkan key → clean architecture

B. Client Factory (FactoryBean)

FactoryBean digunakan untuk membangun API client (RestTemplate/WebClient) sehingga:

- Base URL, timeout, dan konfigurasi lain dapat dikelola via application.yml
- Logic pembuatan client terpisah dari business logic
- Konsisten di seluruh aplikasi
- Lebih fleksibel dibanding mendefinisikan @Bean biasa
- Mendukung central configuration & testability

C. ApplicationRunner for Startup Data

Dipilih dibanding @PostConstruct karena:
-Menjamin semua bean selesai diinisialisasi sebelum kode run
-Menjamin data tersedia sebelum aplikasi menerima request pertama
-Preload hanya sekali (one-time fetch)
-Cocok untuk caching immutable, thread-safe in-memory data

6. Testing

Unit Tests
- Semua Strategy diuji menggunakan mocked API client
- Memverifikasi:
       - Transformasi data
       - Spread calculation
       - Null-handling & edge cases

Integration Test
- Memastikan ApplicationRunner men-load data sebelum context ready
- Memastikan in-memory store terisi sebelum API serve request

Tidak ada panggilan API nyata dalam test (fully mocked).

7. PR Checklist

[x] Strategy Pattern implemented for 3 resources

[x] Custom FactoryBean for RestTemplate/WebClient

[x] ApplicationRunner startup preload

[x] Immutable & thread-safe in-memory storage

[x] Unit tests for all strategies

[x] Integration test for ApplicationRunner

[x] README completed

[x] Spread factor documented

[x] Global Response Filter implemented

 [x]Code formatted, linted, and clean

