### PR TITLE
Implement IDR rate aggregator with Strategy Pattern and in-memory cachingFeat/idr rate aggregator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/README - Tri.md
+++ b/README - Tri.md
@@ -1,0 +1,49 @@
+# Allo Bank Backend Developer Take-Home Test Tri Setyadi
+
+// repo
+git clone https://github.com/allobankdev/allo-backend-test.git
+$ cd allo-backend-test
+git checkout feat/idr-rate-aggregator
+
+// install
+You can use the Maven wrapper or Maven installed locally.
+mvn clean install
+mvn spring-boot:run
+
+// api endpoint
+Base URL
+http://localhost:8081/api/finance/data/{resourceType}
+
+Available resourceType values:
+- latest_idr_rates =	Latest exchange rates from IDR to all supported currencies with USD_BuySpread_IDR
+- historical_idr_usd =	Historical exchange rates from IDR to USD for a fixed date range
+- supported_currencies =	List of all supported currencies and their full names
+
+curl
+curl -X GET http://localhost:8081/api/finance/data/latest_idr_rates
+curl -X GET http://localhost:8081/api/finance/data/historical_idr_usd
+curl -X GET http://localhost:8081/api/finance/data/supported_currencies
+
+// GitHub Username & Spread Factor
+ASCII Sum Calculation:
+s=115, e=101, t=116, y=121, a=97, d=100, i=105, t=116, r=114, i=105
+Total = 1090
+
+Spread Factor Formula:
+Spread Factor = (ASCII Sum % 1000) / 100000.0
+              = (1090 % 1000) / 100000.0
+              = 90 / 100000.0
+              = 0.00090
+
+USD_BuySpread_IDR Calculation Example:
+Rate_USD = 0.00006
+USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)
+                  = 16681.666666666668
+
+Architectural Rationale :
+- Polymorphism Justification (Strategy Pattern)
+Each resource (latest_idr_rates, historical_idr_usd, supported_currencies) is handled by a dedicated strategy class implementing IDRDataFetcher.
+- Client Factory (WebClient via FactoryBean)
+The WebClient instance is constructed using a custom FactoryBean, not a simple @Bean.
+- Startup Runner Choice (ApplicationRunner)
+FinanceDataLoader implements ApplicationRunner to fetch all data at startup.

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.9</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.allo</groupId>
+	<artifactId>finance</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>allo-backend-test</name>
+	<description>allo-backend-test-tri-setyadi-desember-2025</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/allo/finance/AlloBackendTestApplication.java
+++ b/src/main/java/com/allo/finance/AlloBackendTestApplication.java
@@ -2,7 +2,11 @@ package com.allo.finance;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+import com.allo.finance.config.FrankfurterProperties;
+
+@EnableConfigurationProperties(FrankfurterProperties.class)
 @SpringBootApplication
 public class AlloBackendTestApplication {
 

--- a/src/main/java/com/allo/finance/AlloBackendTestApplication.java
+++ b/src/main/java/com/allo/finance/AlloBackendTestApplication.java
@@ -1,0 +1,13 @@
+package com.allo.finance;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AlloBackendTestApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AlloBackendTestApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/allo/finance/client/FrankfurterClient.java
+++ b/src/main/java/com/allo/finance/client/FrankfurterClient.java
@@ -1,0 +1,32 @@
+package com.allo.finance.client;
+
+import com.allo.finance.dto.FrankfurterResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class FrankfurterClient {
+
+    private final WebClient webClient;
+
+    public FrankfurterResponse getLatestRate(
+            String from,
+            String to,
+            Double amount
+    ) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/latest")
+                        .queryParam("from", from)
+                        .queryParam("to", to)
+                        .queryParam("amount", amount)
+                        .build()
+                )
+                .retrieve()
+                .bodyToMono(FrankfurterResponse.class)
+                .block();
+    }
+
+}

--- a/src/main/java/com/allo/finance/client/FrankfurterClientFactoryBean.java
+++ b/src/main/java/com/allo/finance/client/FrankfurterClientFactoryBean.java
@@ -1,0 +1,37 @@
+package com.allo.finance.client;
+
+import com.allo.finance.config.FrankfurterProperties;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class FrankfurterClientFactoryBean implements FactoryBean<WebClient> {
+
+    private final FrankfurterProperties properties;
+
+    public FrankfurterClientFactoryBean(FrankfurterProperties properties) {
+        this.properties = properties;
+    }
+
+    @PostConstruct
+    public void testClient() {
+        System.out.println("Frankfurter Base URL = " + properties.getBaseUrl());
+    }
+
+    @Override
+    public WebClient getObject() {
+        return WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+}

--- a/src/main/java/com/allo/finance/config/FrankfurterProperties.java
+++ b/src/main/java/com/allo/finance/config/FrankfurterProperties.java
@@ -1,0 +1,18 @@
+package com.allo.finance.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "frankfurter")
+public class FrankfurterProperties {
+
+    private String baseUrl;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+    
+}

--- a/src/main/java/com/allo/finance/controller/ExchangeRateController.java
+++ b/src/main/java/com/allo/finance/controller/ExchangeRateController.java
@@ -1,0 +1,25 @@
+package com.allo.finance.controller;
+
+import com.allo.finance.client.FrankfurterClient;
+import com.allo.finance.dto.FrankfurterResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ExchangeRateController {
+
+    private final FrankfurterClient frankfurterClient;
+
+    @GetMapping("/api/rates")
+    public FrankfurterResponse getRate(
+            @RequestParam String from,
+            @RequestParam String to,
+            @RequestParam Double amount
+    ) {
+        return frankfurterClient.getLatestRate(from, to, amount);
+    }
+
+}

--- a/src/main/java/com/allo/finance/controller/FinanceController.java
+++ b/src/main/java/com/allo/finance/controller/FinanceController.java
@@ -1,0 +1,31 @@
+package com.allo.finance.controller;
+
+import com.allo.finance.service.FinanceDataStore;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/finance/data")
+@RequiredArgsConstructor
+public class FinanceController {
+
+    private final FinanceDataStore store;
+
+    @GetMapping("/{resourceType}")
+    public Object getFinanceData(@PathVariable String resourceType) {
+        Object data = store.get(resourceType);
+
+        if (data == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "Unknown resourceType: " + resourceType
+            );
+        }
+
+        return data;
+    }
+
+}

--- a/src/main/java/com/allo/finance/dto/FrankfurterResponse.java
+++ b/src/main/java/com/allo/finance/dto/FrankfurterResponse.java
@@ -1,0 +1,14 @@
+package com.allo.finance.dto;
+
+import lombok.Data;
+import java.util.Map;
+
+@Data
+public class FrankfurterResponse {
+
+    private double amount;
+    private String base;
+    private String date;
+    private Map<String, Double> rates;
+
+}

--- a/src/main/java/com/allo/finance/loader/FinanceDataLoader.java
+++ b/src/main/java/com/allo/finance/loader/FinanceDataLoader.java
@@ -1,0 +1,34 @@
+package com.allo.finance.loader;
+
+import java.util.Map;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import com.allo.finance.service.FinanceDataStore;
+import com.allo.finance.strategy.IDRDataFetcher;
+
+@Component
+public class FinanceDataLoader implements ApplicationRunner {
+
+    private final Map<String, IDRDataFetcher> strategies;
+    private final FinanceDataStore store;
+
+    public FinanceDataLoader(
+            Map<String, IDRDataFetcher> strategies,
+            FinanceDataStore store) {
+        this.strategies = strategies;
+        this.store = store;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        strategies.forEach((beanName, strategy) -> {
+            String resourceType = strategy.getResourceType();
+            Object data = strategy.fetchData();
+            store.put(resourceType, data);
+        });
+    }
+
+}

--- a/src/main/java/com/allo/finance/service/FinanceDataStore.java
+++ b/src/main/java/com/allo/finance/service/FinanceDataStore.java
@@ -1,0 +1,25 @@
+package com.allo.finance.service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FinanceDataStore {
+
+    private final Map<String, Object> store = new ConcurrentHashMap<>();
+
+    public void put(String key, Object value) {
+        store.put(key, value);
+    }
+
+    public Object get(String key) {
+        return store.get(key);
+    }
+
+    public Map<String, Object> snapshot() {
+        return Map.copyOf(store);
+    }
+    
+}

--- a/src/main/java/com/allo/finance/strategy/IDRDataFetcher.java
+++ b/src/main/java/com/allo/finance/strategy/IDRDataFetcher.java
@@ -1,0 +1,19 @@
+package com.allo.finance.strategy;
+
+public interface IDRDataFetcher {
+
+    /**
+     * Identifier resource type
+     * contoh:
+     * - latest_idr_rates
+     * - historical_idr_usd
+     * - supported_currencies
+     */
+    String getResourceType();
+
+    /**
+     * Fetch & transform data
+     */
+    Object fetchData();
+
+}

--- a/src/main/java/com/allo/finance/strategy/impl/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/com/allo/finance/strategy/impl/HistoricalIdrUsdFetcher.java
@@ -1,0 +1,30 @@
+package com.allo.finance.strategy.impl;
+
+import com.allo.finance.strategy.IDRDataFetcher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
+
+    private final WebClient frankfurterWebClient;
+
+    @Override
+    public String getResourceType() {
+        return "historical_idr_usd";
+    }
+
+    @Override
+    public Object fetchData() {
+        return frankfurterWebClient.get()
+                .uri("/2024-01-01..2024-01-05?from=IDR&to=USD")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+}

--- a/src/main/java/com/allo/finance/strategy/impl/LatestIdrRatesFetcher.java
+++ b/src/main/java/com/allo/finance/strategy/impl/LatestIdrRatesFetcher.java
@@ -1,0 +1,53 @@
+package com.allo.finance.strategy.impl;
+
+import com.allo.finance.strategy.IDRDataFetcher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+
+    private final WebClient frankfurterWebClient;
+
+    private static final double SPREAD_FACTOR = 0.00090;
+
+    private double calculateUsdBuySpread(double rateUsd) {
+        return (1 / rateUsd) * (1 + SPREAD_FACTOR);
+    }
+
+    @Override
+    public String getResourceType() {
+        return "latest_idr_rates";
+    }
+
+    @Override
+    public Object fetchData() {
+        Map<String, Object> response = frankfurterWebClient.get()
+                .uri("/latest?base=IDR")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        if (response == null || !response.containsKey("rates")) {
+            return response;
+        }
+
+        Map<String, Object> rates = (Map<String, Object>) response.get("rates");
+
+        if (!rates.containsKey("USD")) {
+            return response;
+        }
+
+        double rateUsd = ((Number) rates.get("USD")).doubleValue();
+
+        Map<String, Object> result = new java.util.HashMap<>(response);
+        result.put("USD_BuySpread_IDR", calculateUsdBuySpread(rateUsd));
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/allo/finance/strategy/impl/SupportedCurrenciesFetcher.java
+++ b/src/main/java/com/allo/finance/strategy/impl/SupportedCurrenciesFetcher.java
@@ -1,0 +1,30 @@
+package com.allo.finance.strategy.impl;
+
+import com.allo.finance.strategy.IDRDataFetcher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    private final WebClient frankfurterWebClient;
+
+    @Override
+    public String getResourceType() {
+        return "supported_currencies";
+    }
+
+    @Override
+    public Object fetchData() {
+        return frankfurterWebClient.get()
+                .uri("/currencies")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 spring.application.name=allo-backend-test
 
 server.port=8081
+
+frankfurter.base-url=https://api.frankfurter.app

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.application.name=allo-backend-test
+
+server.port=8081

--- a/src/test/java/com/allo/finance/AlloBackendTestApplicationTests.java
+++ b/src/test/java/com/allo/finance/AlloBackendTestApplicationTests.java
@@ -1,0 +1,13 @@
+package com.allo.finance;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AlloBackendTestApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/allo/finance/integration/FinanceIntegrationTest.java
+++ b/src/test/java/com/allo/finance/integration/FinanceIntegrationTest.java
@@ -1,0 +1,47 @@
+package com.allo.finance.integration;
+
+import com.allo.finance.service.FinanceDataStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class FinanceIntegrationTest {
+
+    @Autowired
+    private FinanceDataStore store;
+
+    @Test
+    void shouldLoadAllFinanceData() {
+        Map<String, Object> snapshot = store.snapshot();
+
+        assertThat(snapshot).containsKeys(
+            "latest_idr_rates",
+            "historical_idr_usd",
+            "supported_currencies"
+        );
+
+        Map<String, Object> latest = (Map<String, Object>) snapshot.get("latest_idr_rates");
+        assertThat(latest).containsKey("rates");
+        assertThat(latest).containsKey("USD_BuySpread_IDR");
+
+        Map<String, Object> historical = (Map<String, Object>) snapshot.get("historical_idr_usd");
+        assertThat(historical).containsKeys("start_date", "end_date", "rates");
+
+        Map<String, Object> supported = (Map<String, Object>) snapshot.get("supported_currencies");
+        assertThat(supported).containsKey("USD");
+        assertThat(supported).containsKey("IDR");
+
+        double usdBuySpread = ((Number)((Map<String, Object>)latest.get("rates")).get("USD")).doubleValue();
+        assertThat(latest.get("USD_BuySpread_IDR")).isNotNull();
+        assertThat((Double) latest.get("USD_BuySpread_IDR")).isGreaterThan(usdBuySpread);
+
+        Map<String, Object> secondAccess = store.snapshot();
+        assertThat(secondAccess).isEqualTo(snapshot);
+    }
+
+}

--- a/src/test/java/com/allo/finance/strategy/impl/HistoricalIdrUsdFetcherTest.java
+++ b/src/test/java/com/allo/finance/strategy/impl/HistoricalIdrUsdFetcherTest.java
@@ -1,0 +1,36 @@
+package com.allo.finance.strategy.impl;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HistoricalIdrUsdFetcherTest {
+
+    @Test
+    void shouldReturnHistoricalData() {
+        WebClient webClient = Mockito.mock(WebClient.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Map<String, Object> mockResponse = Map.of(
+                "rates", Map.of("2024-01-01", Map.of("USD", 0.000064))
+        );
+
+        Mockito.when(
+                webClient.get()
+                        .uri(Mockito.anyString())
+                        .retrieve()
+                        .bodyToMono(Map.class)
+                        .block()
+        ).thenReturn(mockResponse);
+
+        HistoricalIdrUsdFetcher fetcher = new HistoricalIdrUsdFetcher(webClient);
+
+        Object result = fetcher.fetchData();
+
+        assertThat(result).isNotNull();
+    }
+
+}

--- a/src/test/java/com/allo/finance/strategy/impl/LatestIdrRatesFetcherTest.java
+++ b/src/test/java/com/allo/finance/strategy/impl/LatestIdrRatesFetcherTest.java
@@ -1,0 +1,42 @@
+package com.allo.finance.strategy.impl;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+
+class LatestIdrRatesFetcherTest {
+
+    @Test
+    void shouldCalculateUsdBuySpreadCorrectly() {
+        WebClient webClient = Mockito.mock(WebClient.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Map<String, Object> mockResponse = Map.of(
+                "rates", Map.of("USD", 0.00006)
+        );
+
+        Mockito.when(
+                webClient.get()
+                        .uri(anyString())
+                        .retrieve()
+                        .bodyToMono(Map.class)
+                        .block()
+        ).thenReturn(mockResponse);
+
+        LatestIdrRatesFetcher fetcher = new LatestIdrRatesFetcher(webClient);
+
+        Object result = fetcher.fetchData();
+
+        Map<String, Object> resultMap = (Map<String, Object>) result;
+
+        assertThat(resultMap).containsKey("USD_BuySpread_IDR");
+
+        double spread = (double) resultMap.get("USD_BuySpread_IDR");
+        assertThat(spread).isGreaterThan(0);
+    }
+
+}

--- a/src/test/java/com/allo/finance/strategy/impl/SupportedCurrenciesFetcherTest.java
+++ b/src/test/java/com/allo/finance/strategy/impl/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,40 @@
+package com.allo.finance.strategy.impl;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SupportedCurrenciesFetcherTest {
+
+    @Test
+    void shouldReturnCurrencyList() {
+        WebClient webClient = Mockito.mock(WebClient.class, Mockito.RETURNS_DEEP_STUBS);
+
+        Map<String, String> mockResponse = Map.of(
+                "USD", "United States Dollar",
+                "IDR", "Indonesian Rupiah"
+        );
+
+        Mockito.when(
+                webClient.get()
+                        .uri("/currencies")
+                        .retrieve()
+                        .bodyToMono(Map.class)
+                        .block()
+        ).thenReturn(mockResponse);
+
+        SupportedCurrenciesFetcher fetcher = new SupportedCurrenciesFetcher(webClient);
+
+        Object result = fetcher.fetchData();
+
+        Map<String, String> resultMap = (Map<String, String>) result;
+
+        assertThat(resultMap).containsKey("USD");
+        assertThat(resultMap.get("IDR")).isEqualTo("Indonesian Rupiah");
+    }
+
+}


### PR DESCRIPTION
1. Summary
- Integrates Frankfurter API (latest, historical, supported currencies)
- Uses Strategy Pattern for resourceType resolution
- FactoryBean for WebClient
- Data preloaded at startup (ApplicationRunner)
- Thread-safe in-memory store (FinanceDataStore)
- USD_BuySpread_IDR calculation implemented for latest_idr_rates

2. Endpoints Implemented
GET /api/finance/data/latest_idr_rates
GET /api/finance/data/historical_idr_usd
GET /api/finance/data/supported_currencies

3. Testing
- Unit tests for all strategy fetchers (mock WebClient)
- Integration tests for ApplicationRunner + FinanceDataStore

4. GitHub Username & Spread Factor
GitHub username: setyaditri
Spread Factor: 0.00090

5. Architectural Rationale
- Polymorphism / Strategy Pattern: Clean separation, extensible, controller unaware of fetch logic.
- FactoryBean for WebClient: Centralized config, externalized URL, ready for retries and headers.
- ApplicationRunner: Loads all data at startup, ensures thread-safe immutable store, avoids unnecessary API calls per request.