### PR TITLE
Feat/allobank finance api rashad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+/.idea
+*.iml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,138 +1,114 @@
-# Allo Bank Backend Developer Take-Home Test
+# Allo Bank – IDR Finance Data Aggregator API
 
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
+Spring Boot REST API that aggregates multiple resources from the public **Frankfurter Exchange Rate API**, with a focus on Indonesian Rupiah (IDR).
 
-## 📝 Objective
+This project demonstrates production-ready backend architecture, including Strategy Pattern, startup data loading, immutability, thread safety, and comprehensive testing.
 
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
+---
 
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
+## 📝 Overview
 
-## I. Core Task: The Polymorphic API
+The application exposes a single polymorphic REST endpoint:
 
-### 1. External API Integration (Frankfurter API)
+GET /api/finance/data/{resourceType}
 
-* **Base URL (Public):** `https://api.frankfurter.app/`.
+Supported `{resourceType}` values:
+- latest_idr_rates
+- historical_idr_usd
+- supported_currencies
 
-* You must integrate with three distinct data resources to enforce the architectural pattern:
+All data is fetched once during application startup, stored in an immutable and thread-safe in-memory cache, and served without calling the external API per request.
 
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
+---
 
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
+## ⚙️ Setup & Run Instructions
 
-   3.  `/currencies` (The list of all supported currency symbols)
+### Prerequisites
+- Java 17+
+- Maven 3.8+
+- Git
 
-### 2. Internal API Endpoint
+### Clone Repository
+git clone https://github.com/mrashadyusuf/allo-backend-test.git
+cd allobank-finance-api
 
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
+### Build Application
+mvn clean package
 
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
+### Run Application
+mvn spring-boot:run
 
-### 3. Required Functionality & Business Logic
+Application runs at:
+http://localhost:8080
 
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
+All Frankfurter API resources are fetched once during startup.
 
-* **Data Load:** All three resources should be fetched from the external API.
+### Run Tests
+mvn test
 
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
+This executes:
+- Unit tests for each Strategy (mocked API client)
+- Unit tests for spread calculation
+- Integration test verifying startup data initialization
 
-  **The Spread Factor Must Be Unique :**
+---
 
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
+## 🔌 API Endpoint Usage
 
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
+### Latest IDR Rates (with USD Spread)
+curl http://localhost:8080/api/finance/data/latest_idr_rates
 
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
+### Historical IDR → USD Rates
+curl http://localhost:8080/api/finance/data/historical_idr_usd
 
-## II. Architectural Constraints
+### Supported Currencies
+curl http://localhost:8080/api/finance/data/supported_currencies
 
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
+---
 
-### Constraint A: The Strategy Pattern
+## 🧮 Personalization Note (Spread Factor)
 
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
+GitHub Username:
+mrashadyusuf
 
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
+The GitHub username is configured via application properties and is used only to generate a deterministic spread factor.
 
-2.  Implement **three concrete strategy classes** (one for each resource).
+### Spread Factor Calculation
 
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
+SpreadFactor = (Sum of Unicode values of username % 1000) / 100000.0
 
-### Constraint B: Client Factory Bean
+For username `mrashadyusuf`:
+  - Sum of Unicode values: 1191
+  - Spread Factor: 0.00191
 
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
 
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
+### USD Buy Spread Formula
 
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
+USD_BuySpread_IDR = (1 / Rate_USD) × (1 + SpreadFactor)
 
-### Constraint C: Startup Data Runner & Immutability
+Where Rate_USD is retrieved from:
+https://api.frankfurter.app/latest?base=IDR
 
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
+---
 
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
+## 🏗️ Architecture Summary
 
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
+- Strategy Pattern is used to handle each resource type
+- External API client is constructed via a custom FactoryBean
+- ApplicationRunner loads all data once at startup
+- In-memory store is immutable, thread-safe, and read-only
+- Tests cover unit logic and startup integration
 
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
+---
 
-## III. Production Readiness & Deliverables
+## ✅ Guarantees
 
-Your final solution must demonstrate production quality through code, testing, and communication.
+- External API is never called per request
+- Data is loaded exactly once
+- Safe for concurrent access
+- Deterministic spread calculation per candidate
 
-### 1. Robustness & Best Practices
+---
 
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
-
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
-
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
-
-### 2. Testing
-
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
-
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
-
-### 3. Documentation
-
-A clear `README.md` is mandatory. It must include:
-
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
-
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
-
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
-
-* ---
-
-* ### 🛠️ Architectural Rationale
-
-  This section should contain a brief, but detailed, explanation answering the following questions:
-
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
-
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
-
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
-
-## IV. Submission & Review Process
-
-1.  **Fork** this repository.
-
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
-
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
-
-**Your PR will be evaluated on the following:**
-
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
-
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
-
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
-
-Good luck!
+Author  
+GitHub: mrashadyusuf

--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# AlloBank Finance API (Take-Home)
+
+Implementasi Spring Boot sesuai spesifikasi:
+- **1 endpoint**: `GET /api/finance/data/{resourceType}`
+- **Strategy Pattern** (3 strategy): `latest_idr_rates`, `historical_idr_usd`, `supported_currencies`
+- **WebClient dibuat via `FactoryBean<WebClient>`** (bukan `@Bean`)
+- **Fetch data sekali saat startup** via `ApplicationRunner`
+- **In-memory store immutable & thread-safe** (initialized exactly once)
+
+## Prasyarat
+- Java **17**
+- Maven 3.x
+
+## Cara Menjalankan
+
+1) Edit konfigurasi:
+`src/main/resources/application.yml`
+
+Pastikan:
+- `github.username` diisi dengan **GitHub username kamu**
+- `frankfurter.base-url` tetap `https://api.frankfurter.app`
+
+2) Run:
+```bash
+mvn spring-boot:run
+```
+
+Aplikasi jalan di:
+- `http://localhost:8080`
+
+## Endpoint
+
+### 1) Latest IDR Rates + Spread
+```bash
+curl -s http://localhost:8080/api/finance/data/latest_idr_rates | jq
+```
+
+### 2) Historical IDR→USD (2024-01-01..2024-01-05)
+```bash
+curl -s http://localhost:8080/api/finance/data/historical_idr_usd | jq
+```
+
+### 3) Supported Currencies
+```bash
+curl -s http://localhost:8080/api/finance/data/supported_currencies | jq
+```
+
+## Personalization (Spread Factor)
+Spread Factor dihitung dari GitHub username (lowercase):
+1. Hitung jumlah nilai ASCII semua karakter username.
+2. `Spread Factor = (sum % 1000) / 100000.0`
+
+Formula output:
+`USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)`
+
+> Rate_USD diambil dari Frankfurter `/latest?base=IDR` (nilai `rates.USD`)
+
+## Testing
+
+Jalankan test:
+```bash
+mvn test
+```
+
+Yang diuji:
+- Unit test 3 strategy (transformasi data + spread)
+- Integration test memastikan `ApplicationRunner` menginisialisasi in-memory store saat startup
+
+## Architectural Rationale (Ringkas)
+
+### 1) Kenapa Strategy Pattern?
+Karena endpoint punya 3 *resourceType* dengan aturan berbeda. Strategy membuat kode:
+- mudah ditambah (misal resource baru) tanpa menyentuh controller
+- terpisah dan teruji per resource (single responsibility)
+- lebih maintainable daripada if/else panjang di service/controller
+
+### 2) Kenapa FactoryBean untuk WebClient?
+FactoryBean cocok untuk:
+- membuat objek client yang butuh konfigurasi khusus (baseUrl, timeout)
+- memastikan client dibuat melalui mekanisme Spring lifecycle yang konsisten
+- memisahkan konfigurasi client dari class konfigurasi biasa (`@Bean` method dilarang oleh soal)
+
+### 3) Kenapa ApplicationRunner?
+ApplicationRunner berjalan setelah Spring context siap, sehingga:
+- dependency injection sudah lengkap
+- aman untuk proses startup ingestion (lebih jelas daripada `@PostConstruct`)
+- cocok untuk memuat data sekali lalu dipakai read-only dari in-memory store

--- a/Test Allobank Rashad.postman_collection.json
+++ b/Test Allobank Rashad.postman_collection.json
@@ -1,0 +1,102 @@
+{
+	"info": {
+		"_postman_id": "5f1ff728-af49-427b-bbf2-b29842ba4304",
+		"name": "Test Allobank Rashad",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "25654646"
+	},
+	"item": [
+		{
+			"name": "latest_idr_rates",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8081/api/finance/data/latest_idr_rates",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"api",
+						"finance",
+						"data",
+						"latest_idr_rates"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "supported_currencies",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8081/api/finance/data/supported_currencies",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"api",
+						"finance",
+						"data",
+						"supported_currencies"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "historical_idr_usd",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8081/api/finance/data/historical_idr_usd",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8081",
+					"path": [
+						"api",
+						"finance",
+						"data",
+						"historical_idr_usd"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "frankfurter latest",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://api.frankfurter.app/latest?base=IDR",
+					"protocol": "https",
+					"host": [
+						"api",
+						"frankfurter",
+						"app"
+					],
+					"path": [
+						"latest"
+					],
+					"query": [
+						{
+							"key": "base",
+							"value": "IDR"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.1</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.bezkoder</groupId>
+  <artifactId>allobank-finance-api</artifactId>
+  <version>1.0.0</version>
+  <name>AlloBank Finance API</name>
+  <description>Take-home test - Strategy + FactoryBean + Startup Runner + Immutable In-Memory Store</description>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <!-- REST API -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- WebClient + Reactor Netty for timeouts -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+
+    <!-- Bean validation (optional but useful) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/com/bezkoder/springjwt/AlloBankFinanceApplication.java
+++ b/src/main/java/com/bezkoder/springjwt/AlloBankFinanceApplication.java
@@ -1,0 +1,16 @@
+package com.bezkoder.springjwt;
+
+import com.bezkoder.springjwt.config.FrankfurterProperties;
+import com.bezkoder.springjwt.config.GitHubProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties({FrankfurterProperties.class, GitHubProperties.class})
+public class AlloBankFinanceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AlloBankFinanceApplication.class, args);
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/client/FrankfurterApiClient.java
+++ b/src/main/java/com/bezkoder/springjwt/client/FrankfurterApiClient.java
@@ -1,0 +1,43 @@
+package com.bezkoder.springjwt.client;
+
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Component
+public class FrankfurterApiClient {
+
+    private final WebClient webClient;
+
+    public FrankfurterApiClient(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getLatestBaseIdr() {
+        return webClient.get()
+                .uri("/latest?base=IDR")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getHistoricalIdrToUsd() {
+        return webClient.get()
+                .uri("/2024-01-01..2024-01-05?from=IDR&to=USD")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, String> getCurrencies() {
+        return webClient.get()
+                .uri("/currencies")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/client/FrankfurterWebClientFactoryBean.java
+++ b/src/main/java/com/bezkoder/springjwt/client/FrankfurterWebClientFactoryBean.java
@@ -1,0 +1,42 @@
+package com.bezkoder.springjwt.client;
+
+import com.bezkoder.springjwt.config.FrankfurterProperties;
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+@Component
+public class FrankfurterWebClientFactoryBean implements FactoryBean<WebClient> {
+
+    private final FrankfurterProperties properties;
+
+    public FrankfurterWebClientFactoryBean(FrankfurterProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public WebClient getObject() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getResponseTimeoutMs()));
+
+        return WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/config/FrankfurterProperties.java
+++ b/src/main/java/com/bezkoder/springjwt/config/FrankfurterProperties.java
@@ -1,0 +1,44 @@
+package com.bezkoder.springjwt.config;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "frankfurter")
+public class FrankfurterProperties {
+
+    @NotBlank
+    private String baseUrl;
+
+    @Min(1)
+    private int connectTimeoutMs = 3000;
+
+    @Min(1)
+    private int responseTimeoutMs = 5000;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public void setConnectTimeoutMs(int connectTimeoutMs) {
+        this.connectTimeoutMs = connectTimeoutMs;
+    }
+
+    public int getResponseTimeoutMs() {
+        return responseTimeoutMs;
+    }
+
+    public void setResponseTimeoutMs(int responseTimeoutMs) {
+        this.responseTimeoutMs = responseTimeoutMs;
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/config/GitHubProperties.java
+++ b/src/main/java/com/bezkoder/springjwt/config/GitHubProperties.java
@@ -1,0 +1,21 @@
+package com.bezkoder.springjwt.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "github")
+public class GitHubProperties {
+
+    @NotBlank
+    private String username;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/controllers/FinanceController.java
+++ b/src/main/java/com/bezkoder/springjwt/controllers/FinanceController.java
@@ -1,0 +1,30 @@
+package com.bezkoder.springjwt.controllers;
+
+import com.bezkoder.springjwt.payload.ResourceTypeNotFoundException;
+import com.bezkoder.springjwt.service.StrategyRegistry;
+import com.bezkoder.springjwt.strategy.IDRDataFetcherStrategy;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/finance")
+public class FinanceController {
+
+    private final Map<String, IDRDataFetcherStrategy> strategyMap;
+
+    public FinanceController(StrategyRegistry registry) {
+        this.strategyMap = registry.strategyMap();
+    }
+
+    @GetMapping("/data/{resourceType}")
+    public List<Object> getData(@PathVariable String resourceType) {
+        return Optional.ofNullable(strategyMap.get(resourceType))
+                .map(IDRDataFetcherStrategy::getData)
+                .orElseThrow(() -> new ResourceTypeNotFoundException(resourceType));
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/bezkoder/springjwt/controllers/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.bezkoder.springjwt.controllers;
+
+import com.bezkoder.springjwt.payload.ApiErrorResponse;
+import com.bezkoder.springjwt.payload.ResourceTypeNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceTypeNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(ResourceTypeNotFoundException ex, HttpServletRequest req) {
+        ApiErrorResponse body = new ApiErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ex.getMessage(),
+                req.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalState(IllegalStateException ex, HttpServletRequest req) {
+        ApiErrorResponse body = new ApiErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                ex.getMessage(),
+                req.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/payload/ApiErrorResponse.java
+++ b/src/main/java/com/bezkoder/springjwt/payload/ApiErrorResponse.java
@@ -1,0 +1,38 @@
+package com.bezkoder.springjwt.payload;
+
+import java.time.Instant;
+
+public class ApiErrorResponse {
+    private final Instant timestamp = Instant.now();
+    private final int status;
+    private final String error;
+    private final String message;
+    private final String path;
+
+    public ApiErrorResponse(int status, String error, String message, String path) {
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.path = path;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/payload/ResourceTypeNotFoundException.java
+++ b/src/main/java/com/bezkoder/springjwt/payload/ResourceTypeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.bezkoder.springjwt.payload;
+
+public class ResourceTypeNotFoundException extends RuntimeException {
+    public ResourceTypeNotFoundException(String resourceType) {
+        super("Unknown resourceType: " + resourceType);
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/runner/FinanceStartupRunner.java
+++ b/src/main/java/com/bezkoder/springjwt/runner/FinanceStartupRunner.java
@@ -1,0 +1,35 @@
+package com.bezkoder.springjwt.runner;
+
+import com.bezkoder.springjwt.service.StrategyRegistry;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import com.bezkoder.springjwt.strategy.IDRDataFetcherStrategy;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FinanceStartupRunner implements ApplicationRunner {
+
+    private final StrategyRegistry registry;
+    private final FinanceDataStore store;
+
+    public FinanceStartupRunner(StrategyRegistry registry, FinanceDataStore store) {
+        this.registry = registry;
+        this.store = store;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, List<Object>> loaded = new HashMap<>();
+
+        for (IDRDataFetcherStrategy s : registry.strategyMap().values()) {
+            s.loadAtStartup();
+            loaded.put(s.resourceType(), s.loadedData());
+        }
+
+        store.initialize(loaded);
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/service/StrategyRegistry.java
+++ b/src/main/java/com/bezkoder/springjwt/service/StrategyRegistry.java
@@ -1,0 +1,23 @@
+package com.bezkoder.springjwt.service;
+
+import com.bezkoder.springjwt.strategy.IDRDataFetcherStrategy;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StrategyRegistry {
+
+    private final Map<String, IDRDataFetcherStrategy> strategyMap;
+
+    public StrategyRegistry(List<IDRDataFetcherStrategy> strategies) {
+        this.strategyMap = strategies.stream()
+                .collect(Collectors.toUnmodifiableMap(IDRDataFetcherStrategy::resourceType, Function.identity()));
+    }
+
+    public Map<String, IDRDataFetcherStrategy> strategyMap() {
+        return strategyMap;
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/store/FinanceDataStore.java
+++ b/src/main/java/com/bezkoder/springjwt/store/FinanceDataStore.java
@@ -1,0 +1,37 @@
+package com.bezkoder.springjwt.store;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FinanceDataStore {
+
+    private final AtomicReference<Map<String, List<Object>>> ref =
+            new AtomicReference<>(Collections.emptyMap());
+
+    /**
+     * Initialize store exactly once. After this, data is immutable.
+     */
+    public void initialize(Map<String, List<Object>> loadedData) {
+        Map<String, List<Object>> immutableCopy = Map.copyOf(loadedData);
+        boolean ok = ref.compareAndSet(Collections.emptyMap(), immutableCopy);
+        if (!ok) {
+            throw new IllegalStateException("FinanceDataStore has already been initialized.");
+        }
+    }
+
+    public boolean isInitialized() {
+        return !ref.get().isEmpty();
+    }
+
+    public List<Object> getOrNull(String resourceType) {
+        return ref.get().get(resourceType);
+    }
+
+    public Map<String, List<Object>> snapshot() {
+        return ref.get();
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/strategy/HistoricalIdrUsdStrategy.java
+++ b/src/main/java/com/bezkoder/springjwt/strategy/HistoricalIdrUsdStrategy.java
@@ -1,0 +1,77 @@
+package com.bezkoder.springjwt.strategy;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HistoricalIdrUsdStrategy implements IDRDataFetcherStrategy {
+
+    private static final String TYPE = "historical_idr_usd";
+
+    private final FrankfurterApiClient apiClient;
+    private final FinanceDataStore store;
+
+    private volatile List<Object> loaded = List.of();
+
+    public HistoricalIdrUsdStrategy(FrankfurterApiClient apiClient, FinanceDataStore store) {
+        this.apiClient = apiClient;
+        this.store = store;
+    }
+
+    @Override
+    public String resourceType() {
+        return TYPE;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void loadAtStartup() {
+        Map<String, Object> response = apiClient.getHistoricalIdrToUsd();
+
+        Object baseObj = response.get("base");
+        String base = baseObj != null ? String.valueOf(baseObj) : "IDR";
+
+        Object ratesObj = response.get("rates");
+        if (!(ratesObj instanceof Map)) {
+            throw new IllegalStateException("Invalid response format from historical endpoint");
+        }
+
+        Map<String, Object> ratesByDate = (Map<String, Object>) ratesObj;
+
+        List<Object> list = new ArrayList<>();
+        for (Map.Entry<String, Object> e : ratesByDate.entrySet()) {
+            String date = e.getKey();
+            Object inner = e.getValue();
+
+            if (!(inner instanceof Map)) {
+                continue;
+            }
+            Map<String, Object> innerRates = (Map<String, Object>) inner;
+
+            // Output per-day object: {date, base, rates:{USD:...}}
+            Map<String, Object> out = Map.of(
+                    "date", date,
+                    "base", base,
+                    "rates", Map.copyOf(innerRates)
+            );
+            list.add(out);
+        }
+
+        this.loaded = List.copyOf(list);
+    }
+
+    @Override
+    public List<Object> loadedData() {
+        return loaded;
+    }
+
+    @Override
+    public List<Object> getData() {
+        List<Object> fromStore = store.getOrNull(TYPE);
+        return fromStore != null ? fromStore : List.of();
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/strategy/IDRDataFetcherStrategy.java
+++ b/src/main/java/com/bezkoder/springjwt/strategy/IDRDataFetcherStrategy.java
@@ -1,0 +1,29 @@
+package com.bezkoder.springjwt.strategy;
+
+import java.util.List;
+
+public interface IDRDataFetcherStrategy {
+
+    /**
+     * Must match {resourceType} from GET /api/finance/data/{resourceType}
+     */
+    String resourceType();
+
+    /**
+     * Called once during startup to fetch + transform data.
+     * Implementations must NOT rely on the in-memory store here,
+     * because the store is finalized only after all strategies finish loading.
+     */
+    void loadAtStartup();
+
+    /**
+     * Returns the immutable data produced by loadAtStartup().
+     */
+    List<Object> loadedData();
+
+    /**
+     * Called by controller at runtime; must NOT call external API.
+     * Must serve from in-memory store.
+     */
+    List<Object> getData();
+}

--- a/src/main/java/com/bezkoder/springjwt/strategy/LatestIdrRatesStrategy.java
+++ b/src/main/java/com/bezkoder/springjwt/strategy/LatestIdrRatesStrategy.java
@@ -1,0 +1,75 @@
+package com.bezkoder.springjwt.strategy;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import com.bezkoder.springjwt.util.SpreadCalculator;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LatestIdrRatesStrategy implements IDRDataFetcherStrategy {
+
+    private static final String TYPE = "latest_idr_rates";
+
+    private final FrankfurterApiClient apiClient;
+    private final FinanceDataStore store;
+    private final SpreadCalculator spreadCalculator;
+
+    private volatile List<Object> loaded = List.of();
+
+    public LatestIdrRatesStrategy(FrankfurterApiClient apiClient,
+                                 FinanceDataStore store,
+                                 SpreadCalculator spreadCalculator) {
+        this.apiClient = apiClient;
+        this.store = store;
+        this.spreadCalculator = spreadCalculator;
+    }
+
+    @Override
+    public String resourceType() {
+        return TYPE;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void loadAtStartup() {
+        Map<String, Object> response = apiClient.getLatestBaseIdr();
+
+        Object ratesObj = response.get("rates");
+        if (!(ratesObj instanceof Map)) {
+            throw new IllegalStateException("Invalid response format from /latest?base=IDR");
+        }
+
+        Map<String, Object> rates = (Map<String, Object>) ratesObj;
+        Object usdObj = rates.get("USD");
+        if (!(usdObj instanceof Number)) {
+            throw new IllegalStateException("USD rate not found in /latest?base=IDR");
+        }
+
+        double usdRate = ((Number) usdObj).doubleValue();
+        double usdBuySpreadIdr = spreadCalculator.usdBuySpreadIdr(usdRate);
+
+        double rounded = BigDecimal.valueOf(usdBuySpreadIdr)
+                .setScale(2, RoundingMode.HALF_UP)
+                .doubleValue();
+
+        response.put("USD_BuySpread_IDR", rounded);
+
+        // Store as immutable one-element array
+        this.loaded = List.of(Map.copyOf(response));
+    }
+
+    @Override
+    public List<Object> loadedData() {
+        return loaded;
+    }
+
+    @Override
+    public List<Object> getData() {
+        List<Object> fromStore = store.getOrNull(TYPE);
+        return fromStore != null ? fromStore : List.of();
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/strategy/SupportedCurrenciesStrategy.java
+++ b/src/main/java/com/bezkoder/springjwt/strategy/SupportedCurrenciesStrategy.java
@@ -1,0 +1,55 @@
+package com.bezkoder.springjwt.strategy;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SupportedCurrenciesStrategy implements IDRDataFetcherStrategy {
+
+    private static final String TYPE = "supported_currencies";
+
+    private final FrankfurterApiClient apiClient;
+    private final FinanceDataStore store;
+
+    private volatile List<Object> loaded = List.of();
+
+    public SupportedCurrenciesStrategy(FrankfurterApiClient apiClient, FinanceDataStore store) {
+        this.apiClient = apiClient;
+        this.store = store;
+    }
+
+    @Override
+    public String resourceType() {
+        return TYPE;
+    }
+
+    @Override
+    public void loadAtStartup() {
+        Map<String, String> response = apiClient.getCurrencies();
+
+        List<Object> list = new ArrayList<>();
+        for (Map.Entry<String, String> e : response.entrySet()) {
+            list.add(Map.of(
+                    "code", e.getKey(),
+                    "name", e.getValue()
+            ));
+        }
+
+        this.loaded = List.copyOf(list);
+    }
+
+    @Override
+    public List<Object> loadedData() {
+        return loaded;
+    }
+
+    @Override
+    public List<Object> getData() {
+        List<Object> fromStore = store.getOrNull(TYPE);
+        return fromStore != null ? fromStore : List.of();
+    }
+}

--- a/src/main/java/com/bezkoder/springjwt/util/SpreadCalculator.java
+++ b/src/main/java/com/bezkoder/springjwt/util/SpreadCalculator.java
@@ -1,0 +1,29 @@
+package com.bezkoder.springjwt.util;
+
+import com.bezkoder.springjwt.config.GitHubProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpreadCalculator {
+
+    private final GitHubProperties gitHubProperties;
+
+    public SpreadCalculator(GitHubProperties gitHubProperties) {
+        this.gitHubProperties = gitHubProperties;
+    }
+
+    public double spreadFactor() {
+        String username = gitHubProperties.getUsername().toLowerCase();
+        System.out.println("username "+username);
+        int sum = username.chars().sum();
+        return (sum % 1000) / 100000.0;
+    }
+
+    public double usdBuySpreadIdr(double rateUsdFromBaseIdr) {
+        if (rateUsdFromBaseIdr <= 0.0) {
+            throw new IllegalArgumentException("Rate_USD must be > 0");
+        }
+        double spread = spreadFactor();
+        return (1.0 / rateUsdFromBaseIdr) * (1.0 + spread);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,26 @@
+# ===============================
+# Server
+# ===============================
+server.port=8081
+
+# ===============================
+# Spring Application
+# ===============================
+spring.application.name=allobank-finance-api
+
+# Disable datasource & JPA auto configuration (NO DATABASE)
+spring.autoconfigure.exclude=\
+org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+# ===============================
+# Frankfurter API Configuration
+# ===============================
+frankfurter.base-url=https://api.frankfurter.app
+frankfurter.connect-timeout-ms=3000
+frankfurter.response-timeout-ms=5000
+
+# ===============================
+# GitHub (Spread Factor)
+# ===============================
+github.username=mrashadyusuf

--- a/src/main/resources/application.yml.example
+++ b/src/main/resources/application.yml.example
@@ -1,0 +1,18 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: allobank-finance-api
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+frankfurter:
+  base-url: https://api.frankfurter.app
+  connect-timeout-ms: 3000
+  response-timeout-ms: 5000
+
+github:
+  username: yourgithubusername

--- a/src/test/java/com/bezkoder/springjwt/FinanceStartupIntegrationTest.java
+++ b/src/test/java/com/bezkoder/springjwt/FinanceStartupIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.bezkoder.springjwt;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "github.username=testuser",
+        "frankfurter.base-url=https://api.frankfurter.app"
+})
+class FinanceStartupIntegrationTest {
+
+    //  JUnit + Spring: gunakan field injection
+    @Autowired
+    private FinanceDataStore store;
+
+    //  Stub API client agar tidak call internet
+    @TestConfiguration
+    static class StubConfig {
+
+        @Bean
+        @Primary
+        FrankfurterApiClient frankfurterApiClient() {
+            return new FrankfurterApiClientStub();
+        }
+    }
+
+    //  Stub dengan MUTABLE MAP (WAJIB)
+    static class FrankfurterApiClientStub extends FrankfurterApiClient {
+
+        FrankfurterApiClientStub() {
+            super(null);
+        }
+
+        @Override
+        public Map<String, Object> getLatestBaseIdr() {
+            Map<String, Object> response = new HashMap<>();
+            response.put("base", "IDR");
+            response.put("date", "2026-01-04");
+
+            Map<String, Object> rates = new HashMap<>();
+            rates.put("USD", 0.000064);
+            rates.put("EUR", 0.000058);
+
+            response.put("rates", rates);
+            return response;
+        }
+
+        @Override
+        public Map<String, Object> getHistoricalIdrToUsd() {
+            Map<String, Object> response = new HashMap<>();
+            response.put("base", "IDR");
+
+            Map<String, Object> rates = new HashMap<>();
+            rates.put("2024-01-01", Map.of("USD", 0.000064));
+            rates.put("2024-01-02", Map.of("USD", 0.000063));
+
+            response.put("rates", rates);
+            return response;
+        }
+
+        @Override
+        public Map<String, String> getCurrencies() {
+            Map<String, String> currencies = new HashMap<>();
+            currencies.put("USD", "United States Dollar");
+            currencies.put("IDR", "Indonesian Rupiah");
+            return currencies;
+        }
+    }
+
+    @Test
+    void shouldInitializeInMemoryStoreOnStartup() {
+        assertTrue(store.isInitialized(), "Store harus terinisialisasi saat startup");
+
+        assertNotNull(store.getOrNull("latest_idr_rates"));
+        assertNotNull(store.getOrNull("historical_idr_usd"));
+        assertNotNull(store.getOrNull("supported_currencies"));
+    }
+}

--- a/src/test/java/com/bezkoder/springjwt/HistoricalIdrUsdStrategyTest.java
+++ b/src/test/java/com/bezkoder/springjwt/HistoricalIdrUsdStrategyTest.java
@@ -1,0 +1,36 @@
+package com.bezkoder.springjwt;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import com.bezkoder.springjwt.strategy.HistoricalIdrUsdStrategy;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class HistoricalIdrUsdStrategyTest {
+
+    @Test
+    void shouldTransformHistoricalRatesToArray() {
+        FrankfurterApiClient api = mock(FrankfurterApiClient.class);
+        FinanceDataStore store = new FinanceDataStore();
+
+        when(api.getHistoricalIdrToUsd()).thenReturn(Map.of(
+                "base", "IDR",
+                "rates", Map.of(
+                        "2024-01-01", Map.of("USD", 0.000064),
+                        "2024-01-02", Map.of("USD", 0.000063)
+                )
+        ));
+
+        HistoricalIdrUsdStrategy s = new HistoricalIdrUsdStrategy(api, store);
+        s.loadAtStartup();
+
+        assertEquals(2, s.loadedData().size());
+        Map<String, Object> first = (Map<String, Object>) s.loadedData().get(0);
+        assertTrue(first.containsKey("date"));
+        assertEquals("IDR", first.get("base"));
+        assertTrue(first.containsKey("rates"));
+    }
+}

--- a/src/test/java/com/bezkoder/springjwt/LatestIdrRatesStrategyTest.java
+++ b/src/test/java/com/bezkoder/springjwt/LatestIdrRatesStrategyTest.java
@@ -1,0 +1,47 @@
+package com.bezkoder.springjwt;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.config.GitHubProperties;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import com.bezkoder.springjwt.strategy.LatestIdrRatesStrategy;
+import com.bezkoder.springjwt.util.SpreadCalculator;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class LatestIdrRatesStrategyTest {
+    @Test
+    void shouldAddUsdBuySpreadIdrField() {
+        FrankfurterApiClient api = mock(FrankfurterApiClient.class);
+        FinanceDataStore store = new FinanceDataStore();
+
+        GitHubProperties props = new GitHubProperties();
+        props.setUsername("johndoe47");
+        SpreadCalculator calc = new SpreadCalculator(props);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("base", "IDR");
+        response.put("date", "2026-01-04");
+        response.put("rates", new HashMap<>(Map.of(
+            "USD", 0.000064,
+            "EUR", 0.000058
+        )));
+
+        when(api.getLatestBaseIdr()).thenReturn(response);
+
+        LatestIdrRatesStrategy s =
+            new LatestIdrRatesStrategy(api, store, calc);
+
+        s.loadAtStartup();
+
+        Map<String, Object> obj =
+            (Map<String, Object>) s.loadedData().get(0);
+
+        assertTrue(obj.containsKey("USD_BuySpread_IDR"));
+    }
+
+}

--- a/src/test/java/com/bezkoder/springjwt/SpreadCalculatorTest.java
+++ b/src/test/java/com/bezkoder/springjwt/SpreadCalculatorTest.java
@@ -1,0 +1,38 @@
+package com.bezkoder.springjwt;
+
+import com.bezkoder.springjwt.config.GitHubProperties;
+import com.bezkoder.springjwt.util.SpreadCalculator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SpreadCalculatorTest {
+
+    @Test
+    void shouldComputeSpreadFactorDeterministically() {
+        GitHubProperties props = new GitHubProperties();
+        props.setUsername("johndoe47"); // example
+
+        SpreadCalculator calc = new SpreadCalculator(props);
+
+        // Sum ASCII
+        int expectedSum = "johndoe47".chars().sum();
+        double expectedSpread = (expectedSum % 1000) / 100000.0;
+
+        assertEquals(expectedSpread, calc.spreadFactor(), 1e-12);
+    }
+
+    @Test
+    void shouldComputeUsdBuySpreadIdr() {
+        GitHubProperties props = new GitHubProperties();
+        props.setUsername("abc"); // deterministic
+
+        SpreadCalculator calc = new SpreadCalculator(props);
+
+        double usdRate = 0.000064;
+        double spread = calc.spreadFactor();
+        double expected = (1.0 / usdRate) * (1.0 + spread);
+
+        assertEquals(expected, calc.usdBuySpreadIdr(usdRate), 1e-9);
+    }
+}

--- a/src/test/java/com/bezkoder/springjwt/SupportedCurrenciesStrategyTest.java
+++ b/src/test/java/com/bezkoder/springjwt/SupportedCurrenciesStrategyTest.java
@@ -1,0 +1,32 @@
+package com.bezkoder.springjwt;
+
+import com.bezkoder.springjwt.client.FrankfurterApiClient;
+import com.bezkoder.springjwt.store.FinanceDataStore;
+import com.bezkoder.springjwt.strategy.SupportedCurrenciesStrategy;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class SupportedCurrenciesStrategyTest {
+
+    @Test
+    void shouldTransformCurrenciesToArray() {
+        FrankfurterApiClient api = mock(FrankfurterApiClient.class);
+        FinanceDataStore store = new FinanceDataStore();
+
+        when(api.getCurrencies()).thenReturn(Map.of(
+                "USD", "United States Dollar",
+                "IDR", "Indonesian Rupiah"
+        ));
+
+        SupportedCurrenciesStrategy s = new SupportedCurrenciesStrategy(api, store);
+        s.loadAtStartup();
+
+        assertEquals(2, s.loadedData().size());
+        Map<String, Object> item = (Map<String, Object>) s.loadedData().get(0);
+        assertTrue(item.containsKey("code"));
+        assertTrue(item.containsKey("name"));
+    }
+}


### PR DESCRIPTION
## Summary
This pull request implements a production-ready Spring Boot REST API that aggregates IDR-based financial data from the public Frankfurter Exchange Rate API. The application exposes a single polymorphic endpoint and serves all data from an immutable in-memory cache loaded once during application startup.

## Key Features
- Single endpoint: GET /api/finance/data/{resourceType}
- Strategy Pattern to handle multiple resource types:
  - latest_idr_rates
  - historical_idr_usd
  - supported_currencies
- ApplicationRunner to fetch all external data exactly once at startup
- Immutable and thread-safe in-memory data store
- Deterministic USD buy spread calculation based on GitHub username
- Custom FactoryBean for external API client construction
- Clean separation of controller, service, strategy, and client layers

## Testing
- Unit tests for each IDRDataFetcherStrategy using a stubbed Frankfurter API client
- Unit tests for spread factor and USD buy spread calculation
- Integration test verifying that all data is loaded into the in-memory store during application startup without calling external services

## Architectural Rationale

### 1. Strategy Pattern
The Strategy Pattern is used to encapsulate resource-specific data fetching and transformation logic, allowing the polymorphic endpoint to be easily extended with new resource types without modifying existing controller logic.

### 2. FactoryBean for API Client
A custom FactoryBean is used to centralize the creation and configuration of the Frankfurter API client, providing better lifecycle control and consistency compared to a standard @Bean definition.

### 3. ApplicationRunner
ApplicationRunner is chosen over @PostConstruct to ensure that all Spring beans are fully initialized before triggering external data fetching and in-memory caching during startup.

## Personalization
- GitHub Username: `mrashadysuf`
- Spread Factor: `0.00191`
