### PR TITLE
Feat/idr rate aggregator (ilham : hamramaputra17) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target/
+
+.idea
+*.iws
+*.iml
+*.ipr

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/README.md
+++ b/README.md
@@ -1,139 +1,121 @@
-# Allo Bank Backend Developer Take-Home Test
+# Finance Service – IDR Exchange Data API
+
+Spring Boot application that fetches, processes, and exposes IDR-related financial data using a **Strategy Pattern**, **FactoryBean**, and **startup preloading mechanism**.
+
+---
+
+## Architectural Overview
+
+The application is structured into clearly separated layers:
+
+Controller
+↓
+Service
+↓
+In-Memory Data Store (Immutable Cache)
+↓
+Strategy Registry
+↓
+Fetcher Strategy (Strategy Pattern)
+↓
+External API Client (FactoryBean)
+
+---
+
+### Key Design Decisions
+
+- **Strategy Pattern** for handling multiple resource types without `if/else`
+- **FactoryBean** for external API client creation
+- **ApplicationRunner** to preload all data once at startup
+- **Immutable in-memory cache** for thread safety and performance
+- **Testable units** with mocked external dependencies
+
+---
+
+## Project Structure
+
+src/main/java
+└── allobankdev.test.finance
+├── controller
+│ └── FinanceController.java
+├── service
+│ └── FinanceService.java
+├── store
+│ └── FinanceDataStore.java
+├── registry
+│ └── StrategyRegistry.java
+├── strategy
+│ ├── IDRDataFetcher.java
+│ ├── LatestIdrRatesFetcher.java
+│ ├── HistoricalIdrUsdFetcher.java
+│ └── SupportedCurrenciesFetcher.java
+├── client
+│ └── FrankfurterClient.java
+├── config
+│ ├── FrankfurterProperties.java
+│ └── FrankfurterClientFactoryBean.java
+├── startup
+│ └── FinanceStartupRunner.java
+└── exception
+└── InvalidResourceTypeException.java
+
+src/test/java
+└── allobankdev.test.finance
+├── strategy
+│ ├── LatestIdrRatesFetcherTest.java
+│ ├── HistoricalIdrUsdFetcherTest.java
+│ └── SupportedCurrenciesFetcherTest.java
+└── integration
+└── FinanceStartupIntegrationTest.java
+
+### application.yml
+frankfurter:
+base-url: https://api.frankfurter.app
+
+---
+
+## Tech Stack
+
+- Java 21
+- Spring Boot
+- Spring Web
+- Strategy Pattern
+- FactoryBean
+- JUnit 5 & Mockito
+- JaCoCo (Code Coverage)
+- Maven
+
+---
+
+## Setup & Run Instructions
+
+### Clone Repository
+git clone https://github.com/hamramaputra17/allo-backend-test
+
+### Build Application
+mvn clean package
+
+### Run Tests (with Coverage)
+mvn clean test
+
+JaCoCo coverage report : target/site/jacoco/index.html
 
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
+### Run Application
+mvn spring-boot:run
 
-## 📝 Objective
+### API Endpoint
+GET /api/finance/data/{resourceType}
 
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
+### Example cURL
+- {hostname}/api/finance/data/latest_idr_rates
+- {hostname}/api/finance/data/historical_idr_usd
+- {hostname}/api/finance/data/supported_currencies
 
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
+---
 
-## I. Core Task: The Polymorphic API
+## Spread Factor
+Git Username  : hamramaputra17
 
-### 1. External API Integration (Frankfurter API)
+Unicode Sum   : (sum of Unicode values % 1000) / 100000.0
 
-* **Base URL (Public):** `https://api.frankfurter.app/`.
-
-* You must integrate with three distinct data resources to enforce the architectural pattern:
-
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
-
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
-
-   3.  `/currencies` (The list of all supported currency symbols)
-
-### 2. Internal API Endpoint
-
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
-
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
-
-### 3. Required Functionality & Business Logic
-
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
-
-* **Data Load:** All three resources should be fetched from the external API.
-
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
-
-  **The Spread Factor Must Be Unique :**
-
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
-
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
-
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
-
-## II. Architectural Constraints
-
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
-
-### Constraint A: The Strategy Pattern
-
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
-
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
-
-2.  Implement **three concrete strategy classes** (one for each resource).
-
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
-
-### Constraint B: Client Factory Bean
-
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
-
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
-
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
-
-### Constraint C: Startup Data Runner & Immutability
-
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
-
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
-
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
-
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
-
-## III. Production Readiness & Deliverables
-
-Your final solution must demonstrate production quality through code, testing, and communication.
-
-### 1. Robustness & Best Practices
-
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
-
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
-
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
-
-### 2. Testing
-
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
-
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
-
-### 3. Documentation
-
-A clear `README.md` is mandatory. It must include:
-
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
-
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
-
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
-
-* ---
-
-* ### 🛠️ Architectural Rationale
-
-  This section should contain a brief, but detailed, explanation answering the following questions:
-
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
-
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
-
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
-
-## IV. Submission & Review Process
-
-1.  **Fork** this repository.
-
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
-
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
-4.  Please complete the form to submit your technical test: [Click Here](https://forms.gle/nZKQ2EjTCPfAKHog7)
-
-**Your PR will be evaluated on the following:**
-
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
-
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
-
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
-
-Good luck!
+Spread Factor : 0.00387

--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,2 @@
+frankfurter:
+  base-url: https://api.frankfurter.app

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>allobankdev.test</groupId>
+    <artifactId>finance</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>finance</name>
+    <description>finance</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webservices</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webservices-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+
+                    <!-- Prepare agent -->
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Generate report -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/allobankdev/test/finance/FinanceApplication.java
+++ b/src/main/java/allobankdev/test/finance/FinanceApplication.java
@@ -1,0 +1,16 @@
+package allobankdev.test.finance;
+
+import allobankdev.test.finance.config.FrankfurterProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+
+@SpringBootApplication
+@EnableConfigurationProperties(FrankfurterProperties.class)
+public class FinanceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FinanceApplication.class, args);
+    }
+}
+

--- a/src/main/java/allobankdev/test/finance/ServletInitializer.java
+++ b/src/main/java/allobankdev/test/finance/ServletInitializer.java
@@ -1,0 +1,13 @@
+package allobankdev.test.finance;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+public class ServletInitializer extends SpringBootServletInitializer {
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(FinanceApplication.class);
+    }
+
+}

--- a/src/main/java/allobankdev/test/finance/client/FrankfurterClient.java
+++ b/src/main/java/allobankdev/test/finance/client/FrankfurterClient.java
@@ -1,0 +1,38 @@
+package allobankdev.test.finance.client;
+
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+public class FrankfurterClient {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+
+    public FrankfurterClient(RestTemplate restTemplate, String baseUrl) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+    }
+
+    public Map<String, Object> getLatestIdrRates() {
+        return restTemplate.getForObject(
+                baseUrl + "/latest?base=IDR",
+                Map.class
+        );
+    }
+
+    public Map<String, Object> getHistoricalIdrUsd() {
+        return restTemplate.getForObject(
+                baseUrl + "/2024-01-01..2024-01-05?from=IDR&to=USD",
+                Map.class
+        );
+    }
+
+    public Map<String, Object> getCurrencies() {
+        return restTemplate.getForObject(
+                baseUrl + "/currencies",
+                Map.class
+        );
+    }
+}
+

--- a/src/main/java/allobankdev/test/finance/client/FrankfurterClientFactoryBean.java
+++ b/src/main/java/allobankdev/test/finance/client/FrankfurterClientFactoryBean.java
@@ -1,0 +1,27 @@
+package allobankdev.test.finance.client;
+
+import allobankdev.test.finance.config.FrankfurterProperties;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class FrankfurterClientFactoryBean  implements FactoryBean<FrankfurterClient> {
+
+    private final FrankfurterProperties properties;
+
+    public FrankfurterClientFactoryBean(FrankfurterProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public FrankfurterClient getObject() {
+        RestTemplate restTemplate = new RestTemplate();
+        return new FrankfurterClient(restTemplate, properties.getBaseUrl());
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return FrankfurterClient.class;
+    }
+}

--- a/src/main/java/allobankdev/test/finance/config/FrankfurterProperties.java
+++ b/src/main/java/allobankdev/test/finance/config/FrankfurterProperties.java
@@ -1,0 +1,18 @@
+package allobankdev.test.finance.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "frankfurter")
+public class FrankfurterProperties {
+
+    private String baseUrl;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+}

--- a/src/main/java/allobankdev/test/finance/controller/FinanceController.java
+++ b/src/main/java/allobankdev/test/finance/controller/FinanceController.java
@@ -1,0 +1,31 @@
+package allobankdev.test.finance.controller;
+
+import allobankdev.test.finance.service.FinanceService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/finance")
+public class FinanceController {
+
+    private final FinanceService service;
+
+    public FinanceController(FinanceService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/data/{resourceType}")
+    public ResponseEntity<List<Object>> getData(
+            @PathVariable String resourceType) {
+
+        return ResponseEntity.ok(service.getData(resourceType)
+        );
+    }
+}
+
+

--- a/src/main/java/allobankdev/test/finance/exception/GlobalExceptionHandler.java
+++ b/src/main/java/allobankdev/test/finance/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package allobankdev.test.finance.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidResourceTypeException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidResource(
+            InvalidResourceTypeException ex
+    ) {
+        return ResponseEntity
+                .badRequest()
+                .body(Map.of(
+                        "error", "INVALID_RESOURCE_TYPE",
+                        "message", ex.getMessage()
+                ));
+    }
+}

--- a/src/main/java/allobankdev/test/finance/exception/InvalidResourceTypeException.java
+++ b/src/main/java/allobankdev/test/finance/exception/InvalidResourceTypeException.java
@@ -1,0 +1,11 @@
+package allobankdev.test.finance.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class InvalidResourceTypeException extends RuntimeException {
+    public InvalidResourceTypeException(String type) {
+        super("Invalid resource type: " + type);
+    }
+}

--- a/src/main/java/allobankdev/test/finance/registry/StrategyRegistry.java
+++ b/src/main/java/allobankdev/test/finance/registry/StrategyRegistry.java
@@ -1,0 +1,31 @@
+package allobankdev.test.finance.registry;
+
+import allobankdev.test.finance.strategy.IDRDataFetcher;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class StrategyRegistry {
+
+    private final Map<String, IDRDataFetcher> registry;
+
+    public StrategyRegistry(List<IDRDataFetcher> fetchers) {
+        this.registry = fetchers.stream()
+                .collect(Collectors.toMap(
+                        IDRDataFetcher::resourceType,
+                        Function.identity()
+                ));
+    }
+
+    public IDRDataFetcher get(String type) {
+        IDRDataFetcher fetcher = registry.get(type);
+        if (fetcher == null) {
+//            throw new InvalidResourceTypeException(type);
+        }
+        return fetcher;
+    }
+}

--- a/src/main/java/allobankdev/test/finance/service/FinanceService.java
+++ b/src/main/java/allobankdev/test/finance/service/FinanceService.java
@@ -1,0 +1,28 @@
+package allobankdev.test.finance.service;
+
+import allobankdev.test.finance.exception.InvalidResourceTypeException;
+import allobankdev.test.finance.store.FinanceDataStore;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FinanceService {
+
+    private final FinanceDataStore store;
+
+    public FinanceService(FinanceDataStore store) {
+        this.store = store;
+    }
+
+    public List<Object> getData(String resourceType) {
+        Object data = store.get(resourceType);
+
+        if (data == null) {
+            throw new InvalidResourceTypeException(resourceType);
+        }
+
+        return List.of(store.get(resourceType));
+    }
+}
+

--- a/src/main/java/allobankdev/test/finance/starup/FinanceStartupRunner.java
+++ b/src/main/java/allobankdev/test/finance/starup/FinanceStartupRunner.java
@@ -1,0 +1,44 @@
+package allobankdev.test.finance.starup;
+
+
+import allobankdev.test.finance.registry.StrategyRegistry;
+import allobankdev.test.finance.store.FinanceDataStore;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class FinanceStartupRunner implements ApplicationRunner {
+
+    private final StrategyRegistry registry;
+    private final FinanceDataStore store;
+
+    public FinanceStartupRunner(
+            StrategyRegistry registry,
+            FinanceDataStore store
+    ) {
+        this.registry = registry;
+        this.store = store;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+
+        Map<String, Object> loaded = new HashMap<>();
+
+        for (String type : List.of(
+                "latest_idr_rates",
+                "historical_idr_usd",
+                "supported_currencies")) {
+
+            loaded.put(type, registry.get(type).fetch());
+        }
+
+        store.load(loaded);
+    }
+}
+

--- a/src/main/java/allobankdev/test/finance/store/FinanceDataStore.java
+++ b/src/main/java/allobankdev/test/finance/store/FinanceDataStore.java
@@ -1,0 +1,22 @@
+package allobankdev.test.finance.store;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class FinanceDataStore {
+
+    private Map<String, Object> data;
+
+    public synchronized void load(Map<String, Object> loaded) {
+        this.data = Collections.unmodifiableMap(loaded);
+    }
+
+    public Object get(String key) {
+        return data.get(key);
+    }
+}
+

--- a/src/main/java/allobankdev/test/finance/strategy/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/allobankdev/test/finance/strategy/HistoricalIdrUsdFetcher.java
@@ -1,0 +1,24 @@
+package allobankdev.test.finance.strategy;
+
+import allobankdev.test.finance.client.FrankfurterClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
+
+    private final FrankfurterClient client;
+
+    public HistoricalIdrUsdFetcher(FrankfurterClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String resourceType() {
+        return "historical_idr_usd";
+    }
+
+    @Override
+    public Object fetch() {
+        return client.getHistoricalIdrUsd();
+    }
+}

--- a/src/main/java/allobankdev/test/finance/strategy/IDRDataFetcher.java
+++ b/src/main/java/allobankdev/test/finance/strategy/IDRDataFetcher.java
@@ -1,0 +1,7 @@
+package allobankdev.test.finance.strategy;
+
+public interface IDRDataFetcher {
+    String resourceType();
+
+    Object fetch();
+}

--- a/src/main/java/allobankdev/test/finance/strategy/LatestIdrRatesFetcher.java
+++ b/src/main/java/allobankdev/test/finance/strategy/LatestIdrRatesFetcher.java
@@ -1,0 +1,44 @@
+package allobankdev.test.finance.strategy;
+
+import allobankdev.test.finance.client.FrankfurterClient;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+
+    private static final String USERNAME = "hamramaputra17";
+
+    private final FrankfurterClient client;
+
+    public LatestIdrRatesFetcher(FrankfurterClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String resourceType() {
+        return "latest_idr_rates";
+    }
+
+    @Override
+    public Object fetch() {
+        Map<String, Object> data = client.getLatestIdrRates();
+        Map<String, Object> rates = (Map<String, Object>) data.get("rates");
+
+        double rateUsd = ((Number) rates.get("USD")).doubleValue();
+
+        int sum = USERNAME.toLowerCase().chars().sum();
+        double spread = (sum % 1000) / 100000.0;
+
+        double usdBuySpreadIdr = (1 / rateUsd) * (1 + spread);
+
+        data.put("USD_BuySpread_IDR", usdBuySpreadIdr);
+        data.put("spreadFactor", spread);
+
+        return data;
+    }
+
+}
+
+

--- a/src/main/java/allobankdev/test/finance/strategy/SupportedCurrenciesFetcher.java
+++ b/src/main/java/allobankdev/test/finance/strategy/SupportedCurrenciesFetcher.java
@@ -1,0 +1,25 @@
+package allobankdev.test.finance.strategy;
+
+import allobankdev.test.finance.client.FrankfurterClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    private final FrankfurterClient client;
+
+    public SupportedCurrenciesFetcher(FrankfurterClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public String resourceType() {
+        return "supported_currencies";
+    }
+
+    @Override
+    public Object fetch() {
+        return client.getCurrencies();
+    }
+}
+

--- a/src/test/java/allobankdev/test/finance/FinanceApplicationTests.java
+++ b/src/test/java/allobankdev/test/finance/FinanceApplicationTests.java
@@ -1,0 +1,13 @@
+package allobankdev.test.finance;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FinanceApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/src/test/java/allobankdev/test/finance/integration/FinanceStartupIntegrationTest.java
+++ b/src/test/java/allobankdev/test/finance/integration/FinanceStartupIntegrationTest.java
@@ -1,0 +1,28 @@
+package allobankdev.test.finance.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import allobankdev.test.finance.store.FinanceDataStore;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class FinanceStartupIntegrationTest {
+
+    @Autowired
+    FinanceDataStore store;
+
+    @Test
+    void shouldLoadDataOnStartup() {
+        Object latest = store.get("latest_idr_rates");
+        Object historical = store.get("historical_idr_usd");
+        Object currencies = store.get("supported_currencies");
+
+        assertNotNull(latest);
+        assertNotNull(historical);
+        assertNotNull(currencies);
+    }
+}

--- a/src/test/java/allobankdev/test/finance/startegy/HistoricalIdrUsdFetcherTest.java
+++ b/src/test/java/allobankdev/test/finance/startegy/HistoricalIdrUsdFetcherTest.java
@@ -1,0 +1,35 @@
+package allobankdev.test.finance.startegy;
+
+import allobankdev.test.finance.client.FrankfurterClient;
+import allobankdev.test.finance.strategy.HistoricalIdrUsdFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HistoricalIdrUsdFetcherTest {
+
+    @Mock
+    FrankfurterClient client;
+
+    @Test
+    void shouldReturnHistoricalData() {
+        Map<String, Object> mock = Map.of("rates", Map.of());
+
+        when(client.getHistoricalIdrUsd()).thenReturn(mock);
+
+        HistoricalIdrUsdFetcher fetcher =
+                new HistoricalIdrUsdFetcher(client);
+
+        Object result = fetcher.fetch();
+
+        assertEquals(mock, result);
+    }
+}
+

--- a/src/test/java/allobankdev/test/finance/startegy/LatestIdrRatesFetcherTest.java
+++ b/src/test/java/allobankdev/test/finance/startegy/LatestIdrRatesFetcherTest.java
@@ -1,0 +1,51 @@
+package allobankdev.test.finance.startegy;
+
+import allobankdev.test.finance.client.FrankfurterClient;
+import allobankdev.test.finance.strategy.LatestIdrRatesFetcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LatestIdrRatesFetcherTest {
+
+    @Mock
+    FrankfurterClient client;
+
+    LatestIdrRatesFetcher fetcher;
+
+    @BeforeEach
+    void setup() {
+        fetcher = new LatestIdrRatesFetcher(client);
+    }
+
+    @Test
+    void shouldCalculateUsdBuySpreadCorrectly() {
+        // given
+        Map<String, Object> apiResponse = new HashMap<>();
+        Map<String, Object> rates = Map.of("USD", 0.000064);
+        apiResponse.put("rates", rates);
+
+        when(client.getLatestIdrRates()).thenReturn(apiResponse);
+
+        // when
+        Map<String, Object> result =
+                (Map<String, Object>) fetcher.fetch();
+
+        // then
+        assertTrue(result.containsKey("USD_BuySpread_IDR"));
+
+        double spread = (double) result.get("USD_BuySpread_IDR");
+        assertTrue(spread > 0);
+    }
+}
+

--- a/src/test/java/allobankdev/test/finance/startegy/SupportedCurrenciesFetcherTest.java
+++ b/src/test/java/allobankdev/test/finance/startegy/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,35 @@
+package allobankdev.test.finance.startegy;
+
+import allobankdev.test.finance.client.FrankfurterClient;
+import allobankdev.test.finance.strategy.SupportedCurrenciesFetcher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SupportedCurrenciesFetcherTest {
+
+    @Mock
+    FrankfurterClient client;
+
+    @Test
+    void shouldReturnCurrencies() {
+        Map<String, Object> mock = Map.of("USD", "US Dollar");
+
+        when(client.getCurrencies()).thenReturn(mock);
+
+        SupportedCurrenciesFetcher fetcher =
+                new SupportedCurrenciesFetcher(client);
+
+        Object result = fetcher.fetch();
+
+        assertEquals(mock, result);
+    }
+}
+


### PR DESCRIPTION
Rangkuman
mengambil dan menghitung kurs pertukaran IDR menggunakan pendekatan berbasis strategi yang dapat diperluas. Solusi ini terintegrasi dengan API Frankfurter dan dirancang agar mudah diperluas

- Mengimplementasikan logika agregasi kurs IDR
- Menambahkan klien API Frankfurter menggunakan FactoryBean
- Memperkenalkan pola strategi untuk perhitungan kurs
- Menambahkan pengujian unit untuk perhitungan spread IDR
- Memperbarui konfigurasi dan pengkabelan untuk penyedia kurs

Saya memilih desain berbasis strategi untuk memisahkan logika perhitungan kurs dari sumber data. Ini memungkinkan setiap penyedia kurs memiliki implementasi strateginya sendiri, Pendekatan ini memperkenalkan lapisan abstraksi tambahan, yang sedikit meningkatkan kompleksitas dibandingkan dengan implementasi langsung