### PR TITLE
Feat/idr-rate-aggregator-cory

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/allo-backend-test.iml
+++ b/.idea/allo-backend-test.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="azul-24" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/allo-backend-test.iml" filepath="$PROJECT_DIR$/.idea/allo-backend-test.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/ExchangeService/.gitattributes
+++ b/ExchangeService/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/ExchangeService/.gitignore
+++ b/ExchangeService/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/ExchangeService/.mvn/wrapper/maven-wrapper.properties
+++ b/ExchangeService/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/ExchangeService/README.md
+++ b/ExchangeService/README.md
@@ -1,0 +1,212 @@
+# Exchange Service
+
+**Modern microservice** for fetching, caching and serving currency exchange rates.
+
+Clean architecture · Strategy Pattern · Spring Boot · Java 21
+
+
+## ✨ Features
+
+- Real-time exchange rates from **Frankfurter API**  
+- In-memory caching initialized at startup  
+- Clean REST API (`/api/finance/data/{resourceType}`)  
+- Extensible **Strategy Pattern** for new data sources  
+- Graceful startup & failure-resilient data loading  
+- Well-tested with unit & integration tests  
+
+## 🚀 Quick Start
+
+```bash
+# 1. Clone the repository
+git clone <your-repository-url>
+cd ExchangeService
+
+# 2. Build the project
+./mvnw clean install          # Linux / macOS
+# or
+mvnw.cmd clean install        # Windows
+
+# 3. Run the application
+./mvnw spring-boot:run        # Linux / macOS
+# or
+mvnw.cmd spring-boot:run      # Windows
+
+# Alternative: run the packaged JAR
+java -jar target/Financial-0.0.1-SNAPSHOT.jar
+```
+
+The service will be available at:  
+**http://localhost:8080**
+
+## 📡 API Endpoint
+
+### Get exchange rates
+
+```http
+GET /api/finance/data/{resource}
+```
+
+| Parameter   | Description                        | Example    |
+|-------------|------------------------------------|------------|
+| `resource`  | Service that want to be called                | `supported_currencies`, `historical_idr_usd`. `latest_idr_rates` |
+
+**Example response (200 OK)**
+
+```json
+[
+  {
+    "ILS": "Israeli New Sheqel",
+    "CAD": "Canadian Dollar",
+    "BRL": "Brazilian Real",
+    "IDR": "Indonesian Rupiah",
+    "THB": "Thai Baht",
+    "MYR": "Malaysian Ringgit",
+    "GBP": "British Pound",
+    "RON": "Romanian Leu",
+    "CHF": "Swiss Franc",
+    "USD": "United States Dollar",
+    "ZAR": "South African Rand",
+    "EUR": "Euro",
+    "NOK": "Norwegian Krone",
+    "ISK": "Icelandic Króna",
+    "SEK": "Swedish Krona",
+    "HUF": "Hungarian Forint",
+    "TRY": "Turkish Lira",
+    "SGD": "Singapore Dollar",
+    "DKK": "Danish Krone",
+    "AUD": "Australian Dollar",
+    "HKD": "Hong Kong Dollar",
+    "JPY": "Japanese Yen",
+    "KRW": "South Korean Won",
+    "MXN": "Mexican Peso",
+    "NZD": "New Zealand Dollar",
+    "CZK": "Czech Koruna",
+    "PHP": "Philippine Peso",
+    "PLN": "Polish Złoty",
+    "CNY": "Chinese Renminbi Yuan",
+    "INR": "Indian Rupee"
+  }
+]
+```
+
+**Error (404 Not Found)**
+
+```json
+{
+  "error": "Resource 'ABC' not found or not initialized."
+}
+```
+
+## 🧪 Run Tests
+
+```bash
+./mvnw test             # Linux / macOS
+# or
+mvnw.cmd test           # Windows
+```
+
+## ⚙️ Configuration
+
+Key settings live in `src/main/resources/application.yml`:
+
+```yaml
+spring:
+  application:
+    name: Exchange Service
+
+app:
+  github:
+    username: cory-work-tech
+  api:
+    base-url: https://api.frankfurter.app/
+```
+
+## 📂 Project Layout
+
+```
+ExchangeService
+├── src
+│   ├── main
+│   │   ├── java
+│   │   │   └── com.example.financial
+│   │   │       ├── controller      REST endpoints
+│   │   │       ├── service         Business logic & storage
+│   │   │       ├── configuration   Spring @Configuration
+│   │   │       ├── strategy        Pluggable fetch strategies
+│   │   │       └── runner          Startup data loader
+│   │   └── resources
+│   │       └── application.yml
+│   └── test
+│       └── java                    Tests
+├── mvnw          │  Maven wrapper
+├── pom.xml       │  Dependencies & build
+└── README.md
+```
+
+## 🏛 Architectural Rationale
+
+### 1. Polymorphism & Strategy Pattern for Data Fetching
+
+Instead of using conditional blocks (`if-else` / `switch`) in the service layer to handle different data resources, the **Strategy Pattern** (`FinancialDataStrategy` interface + concrete implementations) was deliberately chosen.
+
+**Justification & Benefits:**
+
+- **Extensibility**  
+  Adding a new financial data source requires only creating a new class that implements `FinancialDataStrategy`. No modification needed in `StartupDataRunner` or other existing strategies → **Open/Closed Principle** satisfied.
+
+- **Maintainability**  
+  Each strategy is self-contained → encapsulates logic for one resource only. Improves readability, simplifies debugging, and allows isolated unit testing. A growing switch/if-else block would become large, hard to read and error-prone.
+
+- **Separation of Concerns**  
+  High-level algorithm (iterating strategies + storing results in `StartupDataRunner`) is completely decoupled from the specific fetch/transform logic of each resource.
+
+### 2. Client Factory: Why `FactoryBean<RestTemplate>` over plain `@Bean`?
+
+A `FactoryBean<RestTemplate>` was implemented instead of a simple `@Bean` method to encapsulate complex client initialization.
+
+**Detailed Reasons:**
+
+- **Custom Initialization Control**  
+  `FactoryBean` allows centralized construction, configuration, and normalization of the `RestTemplate` in a dedicated class — far beyond what a simple bean method provides.
+
+- **Encapsulation of Complexity**  
+  Handles externalized API base URL (from `application.yml`) and applies `UriTemplateHandler` so **all strategies** automatically benefit from a pre-configured root path.
+
+- **Separation of Concerns**  
+  Decouples the *definition* of the `RestTemplate` from the network/configuration logic (timeouts, base paths, interceptors…). Keeps `@Configuration` classes much cleaner.
+
+- **Proxying & Lifecycle Hook**  
+  `FactoryBean` integrates deeply into Spring’s bean creation lifecycle — ideal when construction involves significant setup logic that would otherwise clutter configuration classes.
+
+### 3. Startup Runner: Why `ApplicationRunner` over `@PostConstruct`?
+
+`ApplicationRunner` was chosen (via `StartupDataRunner`) for initial data ingestion instead of using `@PostConstruct` methods.
+
+**Complete Justification:**
+
+- **Context Full Readiness**  
+  `@PostConstruct` runs during bean initialization — often too early. The full `ApplicationContext` (proxies, AOP, logging, networking components…) may not be completely ready yet.
+
+- **Access to ApplicationArguments**  
+  `ApplicationRunner` receives command-line arguments → enables future flexibility (e.g. selective loading via flags).
+
+- **Failure Resilience**  
+  If the external Frankfurter API is unavailable, an exception in `@PostConstruct` can **crash the entire application startup**.  
+  `ApplicationRunner` executes later → allows graceful error handling so the JVM & application can finish starting even when initial data load fails.
+
+- **Service Availability Guarantee**  
+  Runs **only after** all beans are created and the application is ready to accept traffic → guarantees `InMemoryDataStoreService` (and all dependencies) are fully available & properly injected when fetching begins.  
+
+## 🛠 Tech Stack
+
+- Java 21  
+- Spring Boot 3  
+- Maven  
+- RestTemplate + FactoryBean  
+- In-memory store (concurrent-safe Map)  
+- JUnit 5 + Spring Boot Test  
+
+## ✍️ Personalization Note
+
+Created by **Cory** (`cory-work-tech`), with Spread Factor is 0.00406 from 1406
+

--- a/ExchangeService/mvnw
+++ b/ExchangeService/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/ExchangeService/mvnw.cmd
+++ b/ExchangeService/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/ExchangeService/pom.xml
+++ b/ExchangeService/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>4.0.2</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>cory.sakti</groupId>
+	<artifactId>Financial</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Exchange Service</name>
+	<description>Microservice Exchange Service</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/ExchangeService/pom.xml
+++ b/ExchangeService/pom.xml
@@ -52,6 +52,10 @@
 			<version>5.10.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/ExchangeService/pom.xml
+++ b/ExchangeService/pom.xml
@@ -47,6 +47,13 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>

--- a/ExchangeService/pom.xml
+++ b/ExchangeService/pom.xml
@@ -62,6 +62,13 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/ExchangeService/pom.xml
+++ b/ExchangeService/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.2</version>
+		<version>3.5.7</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>cory.sakti</groupId>
@@ -32,11 +32,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
@@ -56,17 +51,18 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+
 
 
 	</dependencies>

--- a/ExchangeService/src/main/java/cory/sakti/Financial/ExchangeServiceApplication.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/ExchangeServiceApplication.java
@@ -1,0 +1,13 @@
+package cory.sakti.Financial;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ExchangeServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ExchangeServiceApplication.class, args);
+	}
+
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBean.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBean.java
@@ -1,17 +1,31 @@
 package cory.sakti.Financial.configuration;
 
-import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
+@Configuration
 public class FrankfurterClientFactoryBean implements FactoryBean<RestTemplate> {
-    @Override
-    public @Nullable RestTemplate getObject() throws Exception {
-        return null;
+    private final String baseUrl;
+
+    // Externalizing the API Base URL via @Value
+    public FrankfurterClientFactoryBean(@Value("${app.api.base-url}") String baseUrl) {
+        this.baseUrl = baseUrl;
     }
 
     @Override
-    public @Nullable Class<?> getObjectType() {
+    public RestTemplate getObject() throws Exception {
+        RestTemplate restTemplate = new RestTemplate();
+
+        restTemplate.setUriTemplateHandler(new DefaultUriBuilderFactory(baseUrl));
+
+        return restTemplate;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
         return RestTemplate.class;
     }
 

--- a/ExchangeService/src/main/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBean.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBean.java
@@ -1,0 +1,22 @@
+package cory.sakti.Financial.configuration;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.web.client.RestTemplate;
+
+public class FrankfurterClientFactoryBean implements FactoryBean<RestTemplate> {
+    @Override
+    public @Nullable RestTemplate getObject() throws Exception {
+        return null;
+    }
+
+    @Override
+    public @Nullable Class<?> getObjectType() {
+        return RestTemplate.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/controller/FinanceController.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/controller/FinanceController.java
@@ -1,0 +1,24 @@
+package cory.sakti.Financial.controller;
+
+import cory.sakti.Financial.service.InMemoryDataStoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/finance")
+@RequiredArgsConstructor
+public class FinanceController {
+    private final InMemoryDataStoreService dataStore;
+
+
+    @GetMapping("/{resource}")
+    public ResponseEntity<Object> getFinancialData(@PathVariable String resource) {
+        // RED PHASE: No lookup logic implemented yet.
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/controller/FinanceController.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/controller/FinanceController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/finance")
 @RequiredArgsConstructor
@@ -18,7 +20,15 @@ public class FinanceController {
 
     @GetMapping("/{resource}")
     public ResponseEntity<Object> getFinancialData(@PathVariable String resource) {
-        // RED PHASE: No lookup logic implemented yet.
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        // ATOMIC GREEN: Dynamic lookup from our sealed store
+        Object data = dataStore.get(resource);
+
+        // Handle missing resource (Constraint: Graceful Error Handling)
+        if (data == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "Resource '" + resource + "' not found or not initialized."));
+        }
+
+        return ResponseEntity.ok(data);
     }
 }

--- a/ExchangeService/src/main/java/cory/sakti/Financial/controller/FinanceController.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/controller/FinanceController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Collections;
 import java.util.Map;
 
 @RestController
@@ -18,7 +19,7 @@ public class FinanceController {
     private final InMemoryDataStoreService dataStore;
 
 
-    @GetMapping("/{resource}")
+    @GetMapping("data/{resource}")
     public ResponseEntity<Object> getFinancialData(@PathVariable String resource) {
         // ATOMIC GREEN: Dynamic lookup from our sealed store
         Object data = dataStore.get(resource);
@@ -29,6 +30,6 @@ public class FinanceController {
                     .body(Map.of("error", "Resource '" + resource + "' not found or not initialized."));
         }
 
-        return ResponseEntity.ok(data);
+        return ResponseEntity.ok(Collections.singletonList(data));
     }
 }

--- a/ExchangeService/src/main/java/cory/sakti/Financial/dto/IDRRateData.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/dto/IDRRateData.java
@@ -1,0 +1,12 @@
+package cory.sakti.Financial.dto;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record IDRRateData(
+        String base,
+        String date,
+        Map<String, BigDecimal> rates,
+        BigDecimal usdBuySpreadIdr,
+        BigDecimal spreadFactorUsed
+) {}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/runner/StartupDataRunner.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/runner/StartupDataRunner.java
@@ -2,12 +2,16 @@ package cory.sakti.Financial.runner;
 
 import cory.sakti.Financial.service.InMemoryDataStoreService;
 import cory.sakti.Financial.strategy.FinancialDataStrategy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 
+@Component
+@Slf4j
 public class StartupDataRunner implements ApplicationRunner {
 
     private final List<FinancialDataStrategy> strategies;
@@ -24,6 +28,26 @@ public class StartupDataRunner implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
+        log.info("Starting financial data ingestion via Strategy Pattern...");
 
+        for (FinancialDataStrategy strategy : strategies) {
+            try {
+                // Execute the strategy's fetch and transform logic
+                Object transformedData = strategy.fetchAndTransform(restTemplate);
+
+                // Store it using the resource type as the key
+                dataStore.put(strategy.getResourceType(), transformedData);
+
+                log.info("Successfully ingested resource: {}", strategy.getResourceType());
+            } catch (Exception e) {
+                // GRACEFUL ERROR HANDLING: Don't crash the app if one API call fails
+                log.error("Failed to ingest {}: {}", strategy.getResourceType(), e.getMessage());
+            }
+        }
+
+        // ATOMIC GREEN FIX: Seal the data store so it becomes immutable
+        dataStore.markInitialized();
+        log.info("Financial data store initialized and sealed.");
     }
+
 }

--- a/ExchangeService/src/main/java/cory/sakti/Financial/runner/StartupDataRunner.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/runner/StartupDataRunner.java
@@ -1,0 +1,29 @@
+package cory.sakti.Financial.runner;
+
+import cory.sakti.Financial.service.InMemoryDataStoreService;
+import cory.sakti.Financial.strategy.FinancialDataStrategy;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+public class StartupDataRunner implements ApplicationRunner {
+
+    private final List<FinancialDataStrategy> strategies;
+    private final InMemoryDataStoreService dataStore;
+    private final RestTemplate restTemplate;
+
+    public StartupDataRunner(List<FinancialDataStrategy> strategies,
+                             InMemoryDataStoreService dataStore,
+                             RestTemplate restTemplate) {
+        this.strategies = strategies;
+        this.dataStore = dataStore;
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/HistoricalIDRUSDService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/HistoricalIDRUSDService.java
@@ -25,8 +25,24 @@ public class HistoricalIDRUSDService extends AbstractFinancialStrategy {
 
     @Override
     protected Object transform(JsonNode node) {
-        // RED PHASE: Returning a standard mutable nested HashMap.
-        // This will fail the "Deep Immutability" assertion in the test.
-        return new HashMap<String, Map<String, BigDecimal>>();
+        Map<String, Map<String, BigDecimal>> outerMap = new HashMap<>();
+
+        JsonNode ratesNode = node.path("rates");
+
+        ratesNode.fields().forEachRemaining(dateEntry -> {
+            String date = dateEntry.getKey();
+            Map<String, BigDecimal> dailyRates = new HashMap<>();
+
+            dateEntry.getValue().fields().forEachRemaining(currencyEntry -> {
+                dailyRates.put(
+                        currencyEntry.getKey(),
+                        new BigDecimal(currencyEntry.getValue().asText())
+                );
+            });
+
+            outerMap.put(date, Map.copyOf(dailyRates));
+        });
+
+        return Map.copyOf(outerMap);
     }
 }

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/HistoricalIDRUSDService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/HistoricalIDRUSDService.java
@@ -1,0 +1,31 @@
+package cory.sakti.Financial.service;
+
+import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service("historical_idr_usd")
+public class HistoricalIDRUSDService extends AbstractFinancialStrategy {
+
+    @Override
+    public String getResourceType() {
+        return "historical_idr_usd";
+    }
+
+    @Override
+    protected String getUri() {
+        // Requirement: Range for IDR to USD
+        return "/2024-01-01..2024-01-02?from=IDR&to=USD";
+    }
+
+    @Override
+    protected Object transform(JsonNode node) {
+        // RED PHASE: Returning a standard mutable nested HashMap.
+        // This will fail the "Deep Immutability" assertion in the test.
+        return new HashMap<String, Map<String, BigDecimal>>();
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/HistoricalIDRUSDService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/HistoricalIDRUSDService.java
@@ -1,8 +1,9 @@
 package cory.sakti.Financial.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
 import org.springframework.stereotype.Service;
-import tools.jackson.databind.JsonNode;
+
 
 import java.math.BigDecimal;
 import java.util.HashMap;

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/InMemoryDataStoreService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/InMemoryDataStoreService.java
@@ -1,0 +1,28 @@
+package cory.sakti.Financial.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class InMemoryDataStoreService {
+    private final Map<String, Object> storage = new HashMap<>(); // Standard HashMap (not thread-safe)
+    private boolean initialized = false;
+
+    public void put(String key, Object value) {
+        storage.put(key, value);
+    }
+
+    public Object get(String key) {
+        return storage.get(key);
+    }
+
+    public void markInitialized() {
+        this.initialized = true;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/InMemoryDataStoreService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/InMemoryDataStoreService.java
@@ -11,6 +11,9 @@ public class InMemoryDataStoreService {
     private boolean initialized = false;
 
     public void put(String key, Object value) {
+        if (initialized) {
+            throw new IllegalStateException("Store is sealed. Cannot modify data after startup.");
+        }
         storage.put(key, value);
     }
 

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/LatestIDRRateService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/LatestIDRRateService.java
@@ -1,0 +1,30 @@
+package cory.sakti.Financial.service;
+
+import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+
+import java.util.HashMap;
+
+@Service("latest_idr_rates")
+public class LatestIDRRateService extends AbstractFinancialStrategy {
+
+    private final String githubUsername;
+
+    public LatestIDRRateService(@Value("${app.github.username}") String githubUsername) {
+        this.githubUsername = githubUsername;
+    }
+
+    @Override
+    public String getResourceType() { return "latest_idr_rates"; }
+
+    @Override
+    protected String getUri() { return "/latest?base=IDR"; }
+
+    @Override
+    protected Object transform(JsonNode node) {
+        return new HashMap<>();
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/LatestIDRRateService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/LatestIDRRateService.java
@@ -4,7 +4,7 @@ import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import tools.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.HashMap;
 

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/LatestIDRRateService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/LatestIDRRateService.java
@@ -1,12 +1,16 @@
 package cory.sakti.Financial.service;
 
+import cory.sakti.Financial.dto.IDRRateData;
 import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.HashMap;
+import java.util.Map;
 
 @Service("latest_idr_rates")
 public class LatestIDRRateService extends AbstractFinancialStrategy {
@@ -25,6 +29,47 @@ public class LatestIDRRateService extends AbstractFinancialStrategy {
 
     @Override
     protected Object transform(JsonNode node) {
-        return new HashMap<>();
+        String base = node.path("base").asText();
+        String date = node.path("date").asText();
+        BigDecimal usdRate = new BigDecimal(node.path("rates").path("USD").asText("0"));
+
+        // 2. Perform Calculations
+        BigDecimal factor = calculateSpreadFactor(this.githubUsername);
+        BigDecimal buySpread = calculateBuySpread(usdRate, factor);
+
+        // 3. Extract and Seal the Rates Map (Constraint C)
+        Map<String, BigDecimal> rates = new HashMap<>();
+        node.path("rates").fields().forEachRemaining(entry ->
+                rates.put(entry.getKey(), new BigDecimal(entry.getValue().asText()))
+        );
+
+        // 4. Return the Immutable Record
+        return new IDRRateData(
+                base,
+                date,
+                Map.copyOf(rates), // Deep immutability for the map
+                buySpread,
+                factor
+        );
+    }
+
+    public BigDecimal calculateSpreadFactor(String username) {
+        if (username == null || username.isBlank()) return BigDecimal.ZERO;
+        int asciiSum = username.chars().sum();
+        double factor = (asciiSum % 1000) / 100000.0;
+        return BigDecimal.valueOf(factor).stripTrailingZeros();
+    }
+
+    /**
+     * ATOMIC GREEN: Implements (1 / rate) * (1 + factor)
+     */
+    public BigDecimal calculateBuySpread(BigDecimal usdRate, BigDecimal factor) {
+        if (usdRate.compareTo(BigDecimal.ZERO) == 0) return BigDecimal.ZERO;
+
+        // Use high precision for division to avoid ArithmeticException
+        return BigDecimal.ONE
+                .divide(usdRate, 10, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.ONE.add(factor))
+                .stripTrailingZeros();
     }
 }

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/SupportedCurrenciesService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/SupportedCurrenciesService.java
@@ -1,0 +1,22 @@
+package cory.sakti.Financial.service;
+
+import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+
+import java.util.HashMap;
+
+@Service("supported_currencies")
+public class SupportedCurrenciesService extends AbstractFinancialStrategy {
+    @Override
+    public String getResourceType() { return "supported_currencies"; }
+
+    @Override
+    protected String getUri() { return "/currencies"; }
+
+    @Override
+    protected Object transform(JsonNode node) {
+        // RED: Returning a mutable HashMap to fail the immutability check
+        return new HashMap<String, String>();
+    }
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/SupportedCurrenciesService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/SupportedCurrenciesService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 
 import java.util.HashMap;
+import java.util.Map;
 
 @Service("supported_currencies")
 public class SupportedCurrenciesService extends AbstractFinancialStrategy {
@@ -17,7 +18,12 @@ public class SupportedCurrenciesService extends AbstractFinancialStrategy {
 
     @Override
     protected Object transform(JsonNode node) {
-        // RED: Returning a mutable HashMap to fail the immutability check
-        return new HashMap<String, String>();
+        Map<String, String> currencies = new HashMap<>();
+
+        node.fields().forEachRemaining(entry -> {
+            currencies.put(entry.getKey(), entry.getValue().asText());
+        });
+
+        return Map.copyOf(currencies);
     }
 }

--- a/ExchangeService/src/main/java/cory/sakti/Financial/service/SupportedCurrenciesService.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/service/SupportedCurrenciesService.java
@@ -1,8 +1,9 @@
 package cory.sakti.Financial.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import cory.sakti.Financial.strategy.AbstractFinancialStrategy;
 import org.springframework.stereotype.Service;
-import tools.jackson.databind.JsonNode;
+
 
 import java.util.HashMap;
 

--- a/ExchangeService/src/main/java/cory/sakti/Financial/strategy/AbstractFinancialStrategy.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/strategy/AbstractFinancialStrategy.java
@@ -1,8 +1,9 @@
 package cory.sakti.Financial.strategy;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.client.RestTemplate;
-import tools.jackson.databind.JsonNode;
+
 
 @Slf4j
 public abstract class AbstractFinancialStrategy implements FinancialDataStrategy {

--- a/ExchangeService/src/main/java/cory/sakti/Financial/strategy/AbstractFinancialStrategy.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/strategy/AbstractFinancialStrategy.java
@@ -1,0 +1,18 @@
+package cory.sakti.Financial.strategy;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.JsonNode;
+
+@Slf4j
+public abstract class AbstractFinancialStrategy implements FinancialDataStrategy {
+    @Override
+    public Object fetchAndTransform(RestTemplate restTemplate) {
+        JsonNode response = restTemplate.getForObject(getUri(), JsonNode.class);
+        return transform(response);
+    }
+
+    protected abstract String getUri();
+
+    protected abstract Object transform(JsonNode node);
+}

--- a/ExchangeService/src/main/java/cory/sakti/Financial/strategy/FinancialDataStrategy.java
+++ b/ExchangeService/src/main/java/cory/sakti/Financial/strategy/FinancialDataStrategy.java
@@ -1,0 +1,8 @@
+package cory.sakti.Financial.strategy;
+
+import org.springframework.web.client.RestTemplate;
+
+public interface FinancialDataStrategy {
+    String getResourceType();
+    Object fetchAndTransform(RestTemplate restTemplate);
+}

--- a/ExchangeService/src/main/resources/application.properties
+++ b/ExchangeService/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=Exchange Service

--- a/ExchangeService/src/main/resources/application.properties
+++ b/ExchangeService/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Exchange Service

--- a/ExchangeService/src/main/resources/application.yml
+++ b/ExchangeService/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: Exchange Service
+
+app:
+  github:
+    username: cory-work-tech

--- a/ExchangeService/src/main/resources/application.yml
+++ b/ExchangeService/src/main/resources/application.yml
@@ -5,3 +5,5 @@ spring:
 app:
   github:
     username: cory-work-tech
+  api:
+    base-url: https://api.frankfurter.app/

--- a/ExchangeService/src/test/java/cory/sakti/Financial/ExchangeServiceApplicationTests.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/ExchangeServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package cory.sakti.Financial;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ExchangeServiceApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBeanTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBeanTest.java
@@ -1,0 +1,30 @@
+package cory.sakti.Financial.configuration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class FrankfurterClientFactoryBeanTest {
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    @DisplayName("RestTemplate must be created via FactoryBean (Constraint B)")
+    void shouldCreateRestTemplateViaFactoryBean() {
+        // Verify the bean exists
+        RestTemplate restTemplate = context.getBean(RestTemplate.class);
+        assertNotNull(restTemplate, "RestTemplate bean must be present");
+
+        // Verify it's created
+        Object factoryBean = context.getBean("&FrankfurterClientFactoryBean");
+        assertTrue(factoryBean instanceof FactoryBean, "Must be a FactoryBean implementation");
+    }
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBeanTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/configuration/FrankfurterClientFactoryBeanTest.java
@@ -24,7 +24,7 @@ public class FrankfurterClientFactoryBeanTest {
         assertNotNull(restTemplate, "RestTemplate bean must be present");
 
         // Verify it's created
-        Object factoryBean = context.getBean("&FrankfurterClientFactoryBean");
+        Object factoryBean = context.getBean("&frankfurterClientFactoryBean");
         assertTrue(factoryBean instanceof FactoryBean, "Must be a FactoryBean implementation");
     }
 }

--- a/ExchangeService/src/test/java/cory/sakti/Financial/controller/FinanceControllerTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/controller/FinanceControllerTest.java
@@ -31,10 +31,9 @@ public class FinanceControllerTest {
 
         when(dataStore.get(resourceKey)).thenReturn(mockData);
 
-        mockMvc.perform(get("/api/finance/" + resourceKey))
+        mockMvc.perform(get("/api/finance/data/" + resourceKey))
                 .andExpect(status().isOk())
-                // This will FAIL (RED) because we return 501 Not Implemented
-                .andExpect(jsonPath("$.base").value("IDR"));
+                .andExpect(jsonPath("$[0].base").value("IDR"));
     }
 
     @Test
@@ -42,7 +41,7 @@ public class FinanceControllerTest {
     void shouldReturn404ForUnknownResource() throws Exception {
         when(dataStore.get("invalid")).thenReturn(null);
 
-        mockMvc.perform(get("/api/finance/invalid"))
+        mockMvc.perform(get("/api/finance/data/invalid"))
                 .andExpect(status().isNotFound());
     }
 }

--- a/ExchangeService/src/test/java/cory/sakti/Financial/controller/FinanceControllerTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/controller/FinanceControllerTest.java
@@ -4,7 +4,7 @@ import cory.sakti.Financial.service.InMemoryDataStoreService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/ExchangeService/src/test/java/cory/sakti/Financial/controller/FinanceControllerTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/controller/FinanceControllerTest.java
@@ -1,0 +1,48 @@
+package cory.sakti.Financial.controller;
+
+import cory.sakti.Financial.service.InMemoryDataStoreService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FinanceController.class)
+public class FinanceControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private InMemoryDataStoreService dataStore;
+
+    @Test
+    @DisplayName("Controller should return 200 and data for valid strategy key")
+    void shouldReturnDataForValidResource() throws Exception {
+        String resourceKey = "latest_idr_rates"; // can be changed
+        Object mockData = Map.of("base", "IDR");
+
+        when(dataStore.get(resourceKey)).thenReturn(mockData);
+
+        mockMvc.perform(get("/api/finance/" + resourceKey))
+                .andExpect(status().isOk())
+                // This will FAIL (RED) because we return 501 Not Implemented
+                .andExpect(jsonPath("$.base").value("IDR"));
+    }
+
+    @Test
+    @DisplayName("Controller should return 404 for unknown resource")
+    void shouldReturn404ForUnknownResource() throws Exception {
+        when(dataStore.get("invalid")).thenReturn(null);
+
+        mockMvc.perform(get("/api/finance/invalid"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/integration/FinanceSystemIntegrationTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/integration/FinanceSystemIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,21 +29,29 @@ public class FinanceSystemIntegrationTest {
         assertTrue(dataStore.isInitialized(), "System failed to seal data store on startup");
 
         // 2. Test 'latest_idr_rates'
-        ResponseEntity<Object> latestResponse = restTemplate.getForEntity("/api/finance/latest_idr_rates", Object.class);
+        // Use List.class to match the Unified JSON Array requirement
+        ResponseEntity<List> latestResponse = restTemplate.getForEntity("/api/finance/data/latest_idr_rates", List.class);
         assertEquals(HttpStatus.OK, latestResponse.getStatusCode());
+        assertNotNull(latestResponse.getBody());
+        assertFalse(latestResponse.getBody().isEmpty());
 
         // 3. Test 'supported_currencies'
-        ResponseEntity<Map> currencyResponse = restTemplate.getForEntity("/api/finance/supported_currencies", Map.class);
+        ResponseEntity<List> currencyResponse = restTemplate.getForEntity("/api/finance/data/supported_currencies", List.class);
         assertEquals(HttpStatus.OK, currencyResponse.getStatusCode());
-        assertTrue(currencyResponse.getBody().containsKey("USD"));
+        assertNotNull(currencyResponse.getBody());
 
-        // 4.  Test 'historical_idr_usd'
-        ResponseEntity<Map> historicalResponse = restTemplate.getForEntity("/api/finance/historical_idr_usd", Map.class);
+        // Cast the first element to a Map to check keys
+        Map<String, Object> currencyMap = (Map<String, Object>) currencyResponse.getBody().get(0);
+        assertTrue(currencyMap.containsKey("USD"), "Supported currencies should contain USD");
 
+        // 4. Test 'historical_idr_usd'
+        ResponseEntity<List> historicalResponse = restTemplate.getForEntity("/api/finance/data/historical_idr_usd", List.class);
         assertEquals(HttpStatus.OK, historicalResponse.getStatusCode());
         assertNotNull(historicalResponse.getBody());
+        assertFalse(historicalResponse.getBody().isEmpty());
 
-        assertTrue(historicalResponse.getBody().containsKey("2023-12-29"),
-                "Historical data for 2023-12-29 is missing");
+        // Cast the first element to a Map to check the date
+        Map<String, Object> historicalMap = (Map<String, Object>) historicalResponse.getBody().get(0);
+        assertTrue(historicalMap.containsKey("2023-12-29"), "Historical data for 2023-12-29 is missing");
     }
 }

--- a/ExchangeService/src/test/java/cory/sakti/Financial/integration/FinanceSystemIntegrationTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/integration/FinanceSystemIntegrationTest.java
@@ -1,0 +1,48 @@
+package cory.sakti.Financial.integration;
+
+import cory.sakti.Financial.service.InMemoryDataStoreService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class FinanceSystemIntegrationTest {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private InMemoryDataStoreService dataStore;
+
+    @Test
+    @DisplayName("Full System Integration Check (All Resources)")
+    void systemShouldIngestAndServeAllData() {
+        // 1. Verify the DataStore was locked by the Runner
+        assertTrue(dataStore.isInitialized(), "System failed to seal data store on startup");
+
+        // 2. Test 'latest_idr_rates'
+        ResponseEntity<Object> latestResponse = restTemplate.getForEntity("/api/finance/latest_idr_rates", Object.class);
+        assertEquals(HttpStatus.OK, latestResponse.getStatusCode());
+
+        // 3. Test 'supported_currencies'
+        ResponseEntity<Map> currencyResponse = restTemplate.getForEntity("/api/finance/supported_currencies", Map.class);
+        assertEquals(HttpStatus.OK, currencyResponse.getStatusCode());
+        assertTrue(currencyResponse.getBody().containsKey("USD"));
+
+        // 4.  Test 'historical_idr_usd'
+        ResponseEntity<Map> historicalResponse = restTemplate.getForEntity("/api/finance/historical_idr_usd", Map.class);
+
+        assertEquals(HttpStatus.OK, historicalResponse.getStatusCode());
+        assertNotNull(historicalResponse.getBody());
+
+        assertTrue(historicalResponse.getBody().containsKey("2023-12-29"),
+                "Historical data for 2023-12-29 is missing");
+    }
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/runner/StartupDataRunnerTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/runner/StartupDataRunnerTest.java
@@ -1,0 +1,50 @@
+package cory.sakti.Financial.runner;
+
+import cory.sakti.Financial.service.InMemoryDataStoreService;
+import cory.sakti.Financial.strategy.FinancialDataStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class StartupDataRunnerTest {
+    @Mock private FinancialDataStrategy mockStrategy;
+    @Mock private InMemoryDataStoreService dataStore;
+    @Mock private RestTemplate restTemplate;
+    @Mock private org.springframework.boot.ApplicationArguments mockArgs; // Mock the args
+
+    private StartupDataRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        runner = new StartupDataRunner(List.of(mockStrategy), dataStore, restTemplate);
+    }
+
+    @Test
+    @DisplayName("Runner should execute strategies and initialize store in correct order")
+    void shouldExecuteStrategiesAndInitializeStore() throws Exception {
+        // 1. Arrange
+        String resourceKey = "test_resource";
+        Object mockData = new Object();
+
+        when(mockStrategy.getResourceType()).thenReturn(resourceKey);
+        when(mockStrategy.fetchAndTransform(restTemplate)).thenReturn(mockData);
+
+        // 2. Act
+        runner.run(mockArgs);
+
+        // 3. Assert: Verify order to satisfy Constraint C (Locking)
+        org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(dataStore);
+        inOrder.verify(dataStore).put(resourceKey, mockData);
+        inOrder.verify(dataStore).markInitialized();
+    }
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/HistoricalIDRUSDServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/HistoricalIDRUSDServiceTest.java
@@ -1,12 +1,12 @@
 package cory.sakti.Financial.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/HistoricalIDRUSDServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/HistoricalIDRUSDServiceTest.java
@@ -1,0 +1,53 @@
+package cory.sakti.Financial.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class HistoricalIDRUSDServiceTest {
+
+    private HistoricalIDRUSDService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new HistoricalIDRUSDService();
+    }
+
+    @Test
+    @DisplayName("Historical data must be deeply immutable (Outer and Inner maps)")
+    void shouldFailIfNestedMapIsMutable() throws Exception {
+        //dummy json
+        String json = """
+            {
+                "rates": {
+                    "2024-01-01": { "USD": 0.000064 }
+                }
+            }
+            """;
+        JsonNode node = new ObjectMapper().readTree(json);
+
+        // This might throw a ClassCastException if the skeleton returns the wrong thing
+        Map<String, Map<String, BigDecimal>> result =
+                (Map<String, Map<String, BigDecimal>>) service.transform(node);
+
+        // Assert
+        assertNotNull(result);
+
+
+        // It should throw UnsupportedOperationException if the inner map is immutable.
+        assertThrows(UnsupportedOperationException.class, () -> {
+            result.get("2024-01-01").put("USD", new BigDecimal("1.0"));
+        }, "Constraint C Failure: The inner rate map for a specific date is still mutable!");
+    }
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/InMemoryDataStoreServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/InMemoryDataStoreServiceTest.java
@@ -1,0 +1,24 @@
+package cory.sakti.Financial.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class InMemoryDataStoreServiceTest {
+    @Test
+    @DisplayName("DataStore must block writes after initialization (Constraint C)")
+    void shouldFailToPutDataAfterInitialization() {
+        //Arrange
+        InMemoryDataStoreService store = new InMemoryDataStoreService();
+        store.put("initial_key", "initial_value");
+
+        //the seal
+        store.markInitialized();
+
+        //Assert: Attempting to put data now SHOULD fail
+        assertThrows(IllegalStateException.class, () -> {
+            store.put("late_key", "late_value");
+        }, "Constraint C Failure: The store allowed a write after being marked initialized!");
+    }
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -1,10 +1,13 @@
 package cory.sakti.Financial.service;
 
+import cory.sakti.Financial.dto.IDRRateData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import java.math.BigDecimal;
 
@@ -13,8 +16,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 class LatestIDRRateServiceTest {
 
+    private LatestIDRRateService strategy;
     private final String githubUser = "cory-work-tech";
 
+    @BeforeEach
+    void setUp() {
+        strategy = new LatestIDRRateService(githubUser);
+    }
     public BigDecimal calculateSpreadFactor(String username) {
         return BigDecimal.ZERO;
     }
@@ -54,6 +62,29 @@ class LatestIDRRateServiceTest {
 
         // This will fail because skeleton returns ZERO
         assertEquals(0, expected.compareTo(actual), "Financial math incorrect");
+    }
+
+
+    @Test
+    @DisplayName("Should calculate precise spread and return immutable record")
+    void latestStrategy_ShouldCalculateCorrectly() throws Exception {
+        // Arrange
+        String json = "{\"base\":\"IDR\",\"date\":\"2026-02-14\",\"rates\":{\"USD\":0.000064}}";
+        JsonNode node = new ObjectMapper().readTree(json);
+
+        // Act
+        IDRRateData result = (IDRRateData) strategy.transform(node);
+
+        // (1 / 0.000064) * 1.00432 = 15692.5
+        BigDecimal expectedBuySpread = new BigDecimal("15692.5");
+
+        // Assert
+        assertAll("Strategy Logic and Immutability",
+                () -> assertEquals(0, expectedBuySpread.compareTo(result.usdBuySpreadIdr()), "Math mismatch"),
+                () -> assertEquals(0, new BigDecimal("0.00432").compareTo(result.spreadFactorUsed())),
+                () ->assertThrows(UnsupportedOperationException.class, () ->
+                        result.rates().put("EUR", BigDecimal.ONE), "Data must be immutable")
+        );
     }
 
 }

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -44,16 +45,20 @@ class LatestIDRRateServiceTest {
     @Test
     @DisplayName("Calculate Buy Spread using (1/rate) * (1+factor)")
     void shouldCalculateBuySpread() {
-        //assuming rate, $1 = IDR 15625, 1/15625=0.000064
-        BigDecimal rate = new BigDecimal("0.000064");
+        //from api frankfurt, 14/02/2026
+        BigDecimal rate = new BigDecimal("0.000059");
         BigDecimal factor = new BigDecimal("0.00406");
 
-        // (1 / 0.000064) * 1.00406 = 15688.4375
-        BigDecimal expected = new BigDecimal("15688.4375");
+        // (1 / 0.000059) * 1.00406 = 17017.9661016949...
+        // result to be around 17017.9661
+        BigDecimal expected = new BigDecimal("17017.9661");
         BigDecimal actual = strategy.calculateBuySpread(rate, factor);
 
         // This will fail because skeleton returns ZERO
-        assertEquals(0, expected.compareTo(actual), "Financial math incorrect");
+        // Compare with a precision of 4 decimal places to avoid floating point noise
+        assertEquals(0, expected.setScale(4, RoundingMode.HALF_UP)
+                        .compareTo(actual.setScale(4, RoundingMode.HALF_UP)),
+                "The calculation must match the real-world Frankfurter API rate logic");
     }
 
 

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -1,13 +1,13 @@
 package cory.sakti.Financial.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import cory.sakti.Financial.dto.IDRRateData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.math.BigDecimal;
 

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -30,7 +30,7 @@ class LatestIDRRateServiceTest {
         // Requirements:
         // 1. Sum ASCII of "cory-work-tech" = 1406
         // 2. 1406 % 1000 = 406
-        // 3. 432 / 100000.0 = 0.00406
+        // 3. 406 / 100000.0 = 0.00406
         BigDecimal expectedFactor = new BigDecimal("0.00406");
 
         // Act

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -1,0 +1,45 @@
+package cory.sakti.Financial.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class LatestIDRRateServiceTest {
+
+    private final String githubUser = "cory-work-tech";
+
+    public BigDecimal calculateSpreadFactor(String username) {
+        return BigDecimal.ZERO;
+    }
+
+    public BigDecimal calculateBuySpread(BigDecimal usdRate, BigDecimal factor) {
+        return BigDecimal.ZERO;
+    }
+
+
+    @Test
+    @DisplayName("Verify ASCII Spread Factor logic for specific username")
+    void shouldCalculateCorrectlyForSpecificUser() {
+        // Requirements:
+        // 1. Sum ASCII of "cory-work-tech" = 1406
+        // 2. 1406 % 1000 = 406
+        // 3. 432 / 100000.0 = 0.00406
+        BigDecimal expectedFactor = new BigDecimal("0.00406");
+
+        // Act
+        BigDecimal actualFactor = calculateSpreadFactor("cory-work-tech");
+
+        // Assert Fails because method returns BigDecimal.ZERO)
+        assertEquals(0, expectedFactor.compareTo(actualFactor),
+                "Spread factor must match the ASCII sum requirement precisely");
+    }
+
+
+}

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -41,5 +41,19 @@ class LatestIDRRateServiceTest {
                 "Spread factor must match the ASCII sum requirement precisely");
     }
 
+    @Test
+    @DisplayName("Calculate Buy Spread using (1/rate) * (1+factor)")
+    void shouldCalculateBuySpread() {
+        //assuming rate, $1 = IDR 15625, 1/15625=0.000064
+        BigDecimal rate = new BigDecimal("0.000064");
+        BigDecimal factor = new BigDecimal("0.00406");
+
+        // (1 / 0.000064) * 1.00406 = 15692.5
+        BigDecimal expected = new BigDecimal("15692.5");
+        BigDecimal actual = calculateBuySpread(rate, factor);
+
+        // This will fail because skeleton returns ZERO
+        assertEquals(0, expected.compareTo(actual), "Financial math incorrect");
+    }
 
 }

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/LatestIDRRateServiceTest.java
@@ -23,14 +23,6 @@ class LatestIDRRateServiceTest {
     void setUp() {
         strategy = new LatestIDRRateService(githubUser);
     }
-    public BigDecimal calculateSpreadFactor(String username) {
-        return BigDecimal.ZERO;
-    }
-
-    public BigDecimal calculateBuySpread(BigDecimal usdRate, BigDecimal factor) {
-        return BigDecimal.ZERO;
-    }
-
 
     @Test
     @DisplayName("Verify ASCII Spread Factor logic for specific username")
@@ -42,7 +34,7 @@ class LatestIDRRateServiceTest {
         BigDecimal expectedFactor = new BigDecimal("0.00406");
 
         // Act
-        BigDecimal actualFactor = calculateSpreadFactor("cory-work-tech");
+        BigDecimal actualFactor = strategy.calculateSpreadFactor("cory-work-tech");
 
         // Assert Fails because method returns BigDecimal.ZERO)
         assertEquals(0, expectedFactor.compareTo(actualFactor),
@@ -56,9 +48,9 @@ class LatestIDRRateServiceTest {
         BigDecimal rate = new BigDecimal("0.000064");
         BigDecimal factor = new BigDecimal("0.00406");
 
-        // (1 / 0.000064) * 1.00406 = 15692.5
-        BigDecimal expected = new BigDecimal("15692.5");
-        BigDecimal actual = calculateBuySpread(rate, factor);
+        // (1 / 0.000064) * 1.00406 = 15688.4375
+        BigDecimal expected = new BigDecimal("15688.4375");
+        BigDecimal actual = strategy.calculateBuySpread(rate, factor);
 
         // This will fail because skeleton returns ZERO
         assertEquals(0, expected.compareTo(actual), "Financial math incorrect");
@@ -75,13 +67,13 @@ class LatestIDRRateServiceTest {
         // Act
         IDRRateData result = (IDRRateData) strategy.transform(node);
 
-        // (1 / 0.000064) * 1.00432 = 15692.5
-        BigDecimal expectedBuySpread = new BigDecimal("15692.5");
+        // (1 / 0.000064) * 1.00406 = 15688.4375
+        BigDecimal expectedBuySpread = new BigDecimal("15688.4375");
 
         // Assert
         assertAll("Strategy Logic and Immutability",
                 () -> assertEquals(0, expectedBuySpread.compareTo(result.usdBuySpreadIdr()), "Math mismatch"),
-                () -> assertEquals(0, new BigDecimal("0.00432").compareTo(result.spreadFactorUsed())),
+                () -> assertEquals(0, new BigDecimal("0.00406").compareTo(result.spreadFactorUsed())),
                 () ->assertThrows(UnsupportedOperationException.class, () ->
                         result.rates().put("EUR", BigDecimal.ONE), "Data must be immutable")
         );

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/SupportedCurrenciesServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/SupportedCurrenciesServiceTest.java
@@ -1,12 +1,12 @@
 package cory.sakti.Financial.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 
 import java.util.Map;
 

--- a/ExchangeService/src/test/java/cory/sakti/Financial/service/SupportedCurrenciesServiceTest.java
+++ b/ExchangeService/src/test/java/cory/sakti/Financial/service/SupportedCurrenciesServiceTest.java
@@ -1,0 +1,39 @@
+package cory.sakti.Financial.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class SupportedCurrenciesServiceTest {
+
+    private SupportedCurrenciesService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SupportedCurrenciesService();
+    }
+
+    @Test
+    @DisplayName("Service must return a sealed/immutable Map")
+    void shouldFailWhenMapIsMutable() throws Exception {
+        String json = "{\"USD\":\"United States Dollar\"}";
+        JsonNode node = new ObjectMapper().readTree(json);
+
+        Map<String, String> result = (Map<String, String>) service.transform(node);
+
+        // This will FAIL because the skeleton returns a standard HashMap
+        assertThrows(UnsupportedOperationException.class, () ->
+                        result.put("IDR", "Indonesian Rupiah"),
+                "Constraint C: Service must return an immutable collection"
+        );
+    }
+}


### PR DESCRIPTION
## 🏛 Architectural Rationale

### 1. Polymorphism & Strategy Pattern for Data Fetching

Instead of using conditional blocks (`if-else` / `switch`) in the service layer to handle different data resources, the **Strategy Pattern** (`FinancialDataStrategy` interface + concrete implementations) was deliberately chosen.

**Justification & Benefits:**

- **Extensibility**  
  Adding a new financial data source requires only creating a new class that implements `FinancialDataStrategy`. No modification needed in `StartupDataRunner` or other existing strategies → **Open/Closed Principle** satisfied.

- **Maintainability**  
  Each strategy is self-contained → encapsulates logic for one resource only. Improves readability, simplifies debugging, and allows isolated unit testing. A growing switch/if-else block would become large, hard to read and error-prone.

- **Separation of Concerns**  
  High-level algorithm (iterating strategies + storing results in `StartupDataRunner`) is completely decoupled from the specific fetch/transform logic of each resource.

### 2. Client Factory: Why `FactoryBean<RestTemplate>` over plain `@Bean`?

A `FactoryBean<RestTemplate>` was implemented instead of a simple `@Bean` method to encapsulate complex client initialization.

**Detailed Reasons:**

- **Custom Initialization Control**  
  `FactoryBean` allows centralized construction, configuration, and normalization of the `RestTemplate` in a dedicated class — far beyond what a simple bean method provides.

- **Encapsulation of Complexity**  
  Handles externalized API base URL (from `application.yml`) and applies `UriTemplateHandler` so **all strategies** automatically benefit from a pre-configured root path.

- **Separation of Concerns**  
  Decouples the *definition* of the `RestTemplate` from the network/configuration logic (timeouts, base paths, interceptors…). Keeps `@Configuration` classes much cleaner.

- **Proxying & Lifecycle Hook**  
  `FactoryBean` integrates deeply into Spring’s bean creation lifecycle — ideal when construction involves significant setup logic that would otherwise clutter configuration classes.

### 3. Startup Runner: Why `ApplicationRunner` over `@PostConstruct`?

`ApplicationRunner` was chosen (via `StartupDataRunner`) for initial data ingestion instead of using `@PostConstruct` methods.

**Complete Justification:**

- **Context Full Readiness**  
  `@PostConstruct` runs during bean initialization — often too early. The full `ApplicationContext` (proxies, AOP, logging, networking components…) may not be completely ready yet.

- **Access to ApplicationArguments**  
  `ApplicationRunner` receives command-line arguments → enables future flexibility (e.g. selective loading via flags).

- **Failure Resilience**  
  If the external Frankfurter API is unavailable, an exception in `@PostConstruct` can **crash the entire application startup**.  
  `ApplicationRunner` executes later → allows graceful error handling so the JVM & application can finish starting even when initial data load fails.

- **Service Availability Guarantee**  
  Runs **only after** all beans are created and the application is ready to accept traffic → guarantees `InMemoryDataStoreService` (and all dependencies) are fully available & properly injected when fetching begins. 