### PR TITLE
Feat/idr rate aggregator by thaufan

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,139 +1,499 @@
-# Allo Bank Backend Developer Take-Home Test
-
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
-
-## 📝 Objective
-
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
-
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
-
-## I. Core Task: The Polymorphic API
-
-### 1. External API Integration (Frankfurter API)
-
-* **Base URL (Public):** `https://api.frankfurter.app/`.
-
-* You must integrate with three distinct data resources to enforce the architectural pattern:
-
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
-
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
-
-   3.  `/currencies` (The list of all supported currency symbols)
-
-### 2. Internal API Endpoint
-
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
-
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
-
-### 3. Required Functionality & Business Logic
-
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
-
-* **Data Load:** All three resources should be fetched from the external API.
-
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
-
-  **The Spread Factor Must Be Unique :**
-
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
-
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
-
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
-
-## II. Architectural Constraints
-
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
-
-### Constraint A: The Strategy Pattern
-
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
-
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
-
-2.  Implement **three concrete strategy classes** (one for each resource).
-
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
-
-### Constraint B: Client Factory Bean
-
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
-
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
-
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
-
-### Constraint C: Startup Data Runner & Immutability
-
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
-
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
-
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
-
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
-
-## III. Production Readiness & Deliverables
-
-Your final solution must demonstrate production quality through code, testing, and communication.
-
-### 1. Robustness & Best Practices
-
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
-
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
-
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
-
-### 2. Testing
-
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
-
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
-
-### 3. Documentation
-
-A clear `README.md` is mandatory. It must include:
-
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
-
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
-
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
-
-* ---
-
-* ### 🛠️ Architectural Rationale
-
-  This section should contain a brief, but detailed, explanation answering the following questions:
-
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
-
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
-
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
-
-## IV. Submission & Review Process
-
-1.  **Fork** this repository.
-
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
-
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
-4.  Please complete the form to submit your technical test: [Click Here](https://forms.gle/nZKQ2EjTCPfAKHog7)
-
-**Your PR will be evaluated on the following:**
-
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
-
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
-
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
-
-Good luck!
+# Allo Bank Finance API — Take-Home Test
+
+> **Candidate:** thaufaniqbal
+> **GitHub:** [@thaufaniqbal](https://github.com/thaufaniqbal)
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Spring Boot 3.2.5 |
+| Language | Java 17 |
+| HTTP Client | WebClient (Spring WebFlux) |
+| Persistence | Spring Data JPA + H2 (in-memory SQL) |
+| Build Tool | Maven |
+| Testing | JUnit 5, Mockito, AssertJ, WireMock |
+| Documentation | SpringDoc OpenAPI (Swagger UI) |
+| Observability | Spring Boot Actuator, MDC Trace Filter |
+
+---
+
+## Personalisasi: Spread Factor
+
+**GitHub Username:** `thaufaniqbal`
+
+| Karakter | Unicode Value |
+|----------|--------------|
+| t | 116 |
+| h | 104 |
+| a | 97 |
+| u | 117 |
+| f | 102 |
+| a | 97 |
+| n | 110 |
+| i | 105 |
+| q | 113 |
+| b | 98 |
+| a | 97 |
+| l | 108 |
+| **Total Sum** | **1264** |
+
+```
+Spread Factor = (1264 % 1000) / 100000.0
+             = 264 / 100000.0
+             = 0.00264
+```
+
+**Formula:**
+```
+USD_BuySpread_IDR = (1 / Rate_USD) * (1 + 0.00264)
+```
+
+---
+
+## Setup & Cara Menjalankan
+
+### Prerequisites
+- Java 17+
+- Maven 3.8+
+
+### Clone & Build
+
+```bash
+git clone https://github.com/thaufaniqbal/allo-bank-finance.git
+cd allo-bank-finance
+mvn clean install -DskipTests
+```
+
+### Jalankan Aplikasi
+
+```bash
+mvn spring-boot:run
+```
+
+Saat startup, `ApplicationRunner` otomatis fetch semua data dari Frankfurter API dan menyimpannya ke in-memory store:
+
+```
+=== Starting financial data initialization ===
+Fetching 3 resource(s): [latest_idr_rates, historical_idr_usd, supported_currencies]
+Successfully loaded and persisted resource: latest_idr_rates
+Successfully loaded and persisted resource: historical_idr_usd
+Successfully loaded and persisted resource: supported_currencies
+FinanceDataStore sealed. 3 resource(s) loaded.
+=== Financial data initialization complete: 3/3 resources loaded successfully ===
+```
+
+### Jalankan Tests
+
+```bash
+# Semua test (unit + integration — fully offline, pakai WireMock)
+mvn test
+
+# Unit tests saja
+mvn test -Dtest="LatestIdrRatesFetcherTest,HistoricalIdrUsdFetcherTest,SupportedCurrenciesFetcherTest,SpreadCalculatorTest,FinanceControllerTest,FinanceDataServiceTest,FinanceDataStoreTest"
+
+# Integration tests saja
+mvn test -Dtest="FinanceDataStartupRunnerIntegrationTest"
+```
+
+### URL yang Tersedia
+
+| URL | Keterangan |
+|-----|------------|
+| `http://localhost:8099/api-docs` | OpenAPI JSON spec |
+| `http://localhost:8099/actuator/health` | Health check |
+| `http://localhost:8099/actuator/info` | App info |
+| `http://localhost:8099/h2-console` | H2 Database console |
+
+**H2 Console credentials:**
+- JDBC URL: `jdbc:h2:mem:allobank`
+- Username: `sa`
+- Password: *(kosong)*
+
+---
+
+## Endpoint
+
+### Base URL
+```
+http://localhost:8099/
+```
+
+### Single Endpoint
+```
+GET /api/finance/data/{resourceType}
+```
+
+---
+
+### 1. Latest IDR Rates
+
+```bash
+curl -X GET http://localhost:8099/api/finance/data/latest_idr_rates \
+  -H "Accept: application/json" | jq .
+```
+
+**Response (HTTP 200):**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "timestamp": "2024-01-05T08:00:00.000Z",
+  "data": {
+    "resourceType": "latest_idr_rates",
+    "fetchedAt": "2024-01-05T08:00:00.000Z",
+    "data": {
+      "amount": "1",
+      "base": "IDR",
+      "date": "2024-01-05",
+      "rates": {
+        "USD": 0.000064,
+        "EUR": 0.000059
+      }
+    },
+    "usdBuySpreadIdr": 15666.75,
+    "spreadFactor": 0.00264
+  }
+}
+```
+
+---
+
+### 2. Historical IDR/USD Rates
+
+```bash
+curl -X GET http://localhost:8099/api/finance/data/historical_idr_usd \
+  -H "Accept: application/json" | jq .
+```
+
+**Response (HTTP 200):**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "timestamp": "2024-01-05T08:00:01.000Z",
+  "data": {
+    "resourceType": "historical_idr_usd",
+    "fetchedAt": "2024-01-05T08:00:01.000Z",
+    "data": {
+      "amount": "1",
+      "base": "IDR",
+      "start_date": "2024-01-01",
+      "end_date": "2024-01-05",
+      "rates": {
+        "2024-01-02": { "USD": 0.000064 },
+        "2024-01-03": { "USD": 0.000065 },
+        "2024-01-05": { "USD": 0.000063 }
+      }
+    }
+  }
+}
+```
+
+---
+
+### 3. Supported Currencies
+
+```bash
+curl -X GET http://localhost:8099/api/finance/data/supported_currencies \
+  -H "Accept: application/json" | jq .
+```
+
+**Response (HTTP 200):**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "timestamp": "2024-01-05T08:00:02.000Z",
+  "data": {
+    "resourceType": "supported_currencies",
+    "fetchedAt": "2024-01-05T08:00:02.000Z",
+    "data": {
+      "AUD": "Australian Dollar",
+      "IDR": "Indonesian Rupiah",
+      "USD": "US Dollar",
+      "EUR": "Euro"
+    }
+  }
+}
+```
+
+---
+
+### Error Responses
+
+**Resource type tidak valid (HTTP 404):**
+```bash
+curl -X GET http://localhost:8099/api/finance/data/invalid_type | jq .
+```
+```json
+{
+  "success": false,
+  "message": "Resource type 'invalid_type' not found. Valid types are: latest_idr_rates, historical_idr_usd, supported_currencies",
+  "timestamp": "2024-01-05T08:00:05.000Z"
+}
+```
+
+**HTTP method salah (HTTP 405):**
+```bash
+curl -X POST http://localhost:8099/api/finance/data/latest_idr_rates | jq .
+```
+```json
+{
+  "success": false,
+  "message": "Request method 'POST' is not supported",
+  "timestamp": "2024-01-05T08:00:06.000Z"
+}
+```
+
+---
+
+## Struktur Project
+
+```
+src/
+├── main/
+│   ├── java/com/allobank/finance/
+│   │   ├── FinanceApplication.java               # Entry point
+│   │   ├── client/
+│   │   │   └── WebClientFactoryBean.java         # FactoryBean<WebClient>
+│   │   ├── config/
+│   │   │   ├── AppProperties.java                # @ConfigurationProperties
+│   │   │   ├── FetcherConfig.java                # Strategy Map<String, IDRDataFetcher>
+│   │   │   ├── FrankfurterProperties.java        # Config untuk external API
+│   │   │   └── OpenApiConfig.java                # Swagger/OpenAPI metadata
+│   │   ├── controller/
+│   │   │   └── FinanceController.java            # GET /api/finance/data/{resourceType}
+│   │   ├── dto/
+│   │   │   ├── ApiResponse.java                  # Generic response wrapper
+│   │   │   ├── FinanceDataResponse.java           # Unified response model
+│   │   │   └── FrankfurterDto.java               # DTO untuk Frankfurter API
+│   │   ├── entity/
+│   │   │   └── FinanceDataCache.java             # JPA entity
+│   │   ├── exception/
+│   │   │   ├── GlobalExceptionHandler.java       # @RestControllerAdvice
+│   │   │   └── ResourceNotFoundException.java    # Custom 404 exception
+│   │   ├── fetcher/
+│   │   │   ├── IDRDataFetcher.java               # Strategy Interface
+│   │   │   ├── LatestIdrRatesFetcher.java        # Strategy #1 + spread calculation
+│   │   │   ├── HistoricalIdrUsdFetcher.java      # Strategy #2
+│   │   │   ├── SupportedCurrenciesFetcher.java   # Strategy #3
+│   │   │   └── SpreadCalculator.java             # Spread factor logic
+│   │   ├── filter/
+│   │   │   └── MdcTraceFilter.java               # MDC traceId per request
+│   │   ├── repository/
+│   │   │   └── FinanceDataCacheRepository.java   # JPA repository
+│   │   ├── runner/
+│   │   │   └── FinanceDataStartupRunner.java     # ApplicationRunner
+│   │   └── service/
+│   │       ├── FinanceDataService.java            # Business logic
+│   │       └── FinanceDataStore.java             # Thread-safe in-memory store
+│   └── resources/
+│       └── application.properties
+└── test/
+    ├── java/com/allobank/finance/
+    │   ├── controller/
+    │   │   └── FinanceControllerTest.java
+    │   ├── fetcher/
+    │   │   ├── LatestIdrRatesFetcherTest.java
+    │   │   ├── HistoricalIdrUsdFetcherTest.java
+    │   │   ├── SupportedCurrenciesFetcherTest.java
+    │   │   └── SpreadCalculatorTest.java
+    │   ├── service/
+    │   │   ├── FinanceDataServiceTest.java
+    │   │   └── FinanceDataStoreTest.java
+    │   └── integration/
+    │       └── FinanceDataStartupRunnerIntegrationTest.java
+    └── resources/
+        └── application-test.yml
+```
+
+---
+
+## Penjelasan Arsitektur
+
+### 1. Kenapa Pakai Strategy Pattern?
+
+Kalau pakai conditional if/else biasa:
+
+```java
+// Cara lama — tiap tambah resource type harus ubah class ini
+public FinanceDataResponse getData(String resourceType) {
+    if (resourceType.equals("latest_idr_rates")) {
+        return fetchLatest();
+    } else if (resourceType.equals("historical_idr_usd")) {
+        return fetchHistorical();
+    } else if (resourceType.equals("supported_currencies")) {
+        return fetchCurrencies();
+    }
+    throw new ResourceNotFoundException(...);
+}
+```
+
+Masalahnya setiap kali ada resource type baru, kita harus ubah class yang sudah ada dan sudah di-test. Rawan bug.
+
+Solusinya pakai Strategy Pattern:
+
+```java
+// Interface sebagai kontrak
+public interface IDRDataFetcher {
+    FinanceDataResponse fetch();
+    String getResourceType();
+}
+
+// Tiap strategy berdiri sendiri
+@Component
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+    @Override public String getResourceType() { return "latest_idr_rates"; }
+    @Override public FinanceDataResponse fetch() { ... }
+}
+
+// FetcherConfig otomatis build map-nya, controller bebas dari conditional
+@Bean
+public Map<String, IDRDataFetcher> fetcherMap(List<IDRDataFetcher> fetchers) {
+    return fetchers.stream()
+        .collect(Collectors.toMap(IDRDataFetcher::getResourceType, Function.identity()));
+}
+```
+
+Kalau mau tambah resource type baru, tinggal buat satu class baru. Tidak ada code lama yang perlu diubah.
+
+---
+
+### 2. Kenapa Pakai FactoryBean, bukan @Bean Biasa?
+
+Dengan `@Bean` biasa konfigurasinya flat dan inline. Pakai `FactoryBean<WebClient>` kita bisa pisahkan semua konfigurasi Netty, timeout, dan connector ke dalam satu class tersendiri yang lebih terorganisir dan mudah di-test secara independen.
+
+```java
+@Component
+public class WebClientFactoryBean implements FactoryBean<WebClient> {
+
+    private final FrankfurterProperties properties;
+
+    @Override
+    public WebClient getObject() throws Exception {
+        HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+            .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()))
+            .doOnConnected(conn ->
+                conn.addHandlerLast(new ReadTimeoutHandler(...))
+                    .addHandlerLast(new WriteTimeoutHandler(...)));
+
+        return WebClient.builder()
+            .baseUrl(properties.getBaseUrl())
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    @Override public Class<?> getObjectType() { return WebClient.class; }
+    @Override public boolean isSingleton() { return true; }
+}
+```
+
+`isSingleton() = true` karena WebClient itu stateless dan thread-safe, jadi satu instance cukup untuk semua fetcher.
+
+---
+
+### 3. Kenapa Pakai ApplicationRunner, bukan @PostConstruct?
+
+`@PostConstruct` berjalan saat bean diinisialisasi, sebelum ApplicationContext sepenuhnya siap. Risikonya JPA transaction manager dan Netty belum tentu sudah ready, bisa muncul `LazyInitializationException` atau `TransactionRequiredException`.
+
+`ApplicationRunner` dijamin berjalan setelah semua bean selesai diinisialisasi, jadi JPA dan WebClient sudah pasti siap dipakai.
+
+```java
+@Component
+public class FinanceDataStartupRunner implements ApplicationRunner {
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        for (Map.Entry<String, IDRDataFetcher> entry : fetcherMap.entrySet()) {
+            FinanceDataResponse response = entry.getValue().fetch();
+            financeDataStore.put(entry.getKey(), response);
+            cacheRepository.save(...);
+        }
+        financeDataStore.seal();
+    }
+}
+```
+
+Kalau salah satu resource gagal di-fetch, runner tetap lanjut ke resource berikutnya. Store di-seal tetap, jadi data yang berhasil dimuat masih bisa dilayani.
+
+---
+
+### 4. Thread-Safe Immutable Store
+
+```java
+@Component
+public class FinanceDataStore {
+
+    // ConcurrentHashMap: thread-safe untuk concurrent read dan write saat loading
+    private final ConcurrentHashMap<String, FinanceDataResponse> store = new ConcurrentHashMap<>();
+    
+    // AtomicBoolean: lock-free, thread-safe untuk sealed flag
+    private final AtomicBoolean sealed = new AtomicBoolean(false);
+
+    public void put(String key, FinanceDataResponse value) {
+        if (sealed.get()) {
+            throw new IllegalStateException("FinanceDataStore is sealed. No writes allowed.");
+        }
+        store.put(key, value);
+    }
+
+    public void seal() {
+        sealed.compareAndSet(false, true);
+    }
+
+    public Map<String, FinanceDataResponse> getAll() {
+        return Collections.unmodifiableMap(store);
+    }
+}
+```
+
+Setelah `seal()` dipanggil, tidak ada write yang bisa masuk. Semua read aman tanpa locking karena `ConcurrentHashMap` menjamin visibility-nya.
+
+---
+
+### 5. API Versioning
+
+```
+GET /api/v1/finance/data/{resourceType}
+```
+
+Pakai URI versioning (`/v1`) supaya langsung keliatan dari URL-nya, mudah dibaca di log, dan kompatibel dengan semua HTTP client tanpa perlu custom header. Ini juga jadi standar umum di fintech API seperti Midtrans dan Xendit.
+
+karena kebutuhan untuk allo bank test, itu harus di sesuaikan menjadi 
+
+```
+GET /api/finance/data/{resourceType}
+```
+---
+
+### 6. MDC Request Tracing
+
+```java
+@Component
+@Order(1)
+public class MdcTraceFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) {
+        String traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+        try {
+            MDC.put("traceId", traceId);
+            httpResponse.setHeader("X-Trace-Id", traceId);
+            chain.doFilter(request, response);
+        } finally {
+            MDC.clear(); // Wajib clear untuk mencegah ThreadLocal leak di thread pool
+        }
+    }
+}
+```
+
+Setiap log otomatis menyertakan `[traceId]`:
+```
+2024-01-05 08:00:01 [http-nio-8099-exec-1] [a3f9b2c1d4e56789] INFO  FinanceController - GET /api/finance/data/latest_idr_rates
+```
+
+`traceId` yang sama juga dikembalikan lewat response header `X-Trace-Id`, jadi client bisa korelasikan request mereka dengan log di server.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.allobank</groupId>
+    <artifactId>finance</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>allo-bank-finance</name>
+    <description>Allo Bank Backend Developer Take-Home Test</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <wiremock.version>3.3.1</wiremock.version>
+        <springdoc.version>2.3.0</springdoc.version>
+    </properties>
+
+    <dependencies>
+        <!-- Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- WebFlux (for WebClient) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- Actuator -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- OpenAPI / Swagger -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <!-- H2 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Configuration Properties Processor -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- WireMock -->
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/allobank/finance/FinanceApplication.java
+++ b/src/main/java/com/allobank/finance/FinanceApplication.java
@@ -1,9 +1,13 @@
 package com.allobank.finance;
 
+import com.allobank.finance.config.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import com.allobank.finance.config.FrankfurterProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties({FrankfurterProperties.class, AppProperties.class})
 public class FinanceApplication {
     public static void main(String[] args) {
         SpringApplication.run(FinanceApplication.class, args);

--- a/src/main/java/com/allobank/finance/FinanceApplication.java
+++ b/src/main/java/com/allobank/finance/FinanceApplication.java
@@ -1,0 +1,11 @@
+package com.allobank.finance;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FinanceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FinanceApplication.class, args);
+    }
+}

--- a/src/main/java/com/allobank/finance/client/WebClientFactoryBean.java
+++ b/src/main/java/com/allobank/finance/client/WebClientFactoryBean.java
@@ -1,0 +1,48 @@
+package com.allobank.finance.client;
+
+import com.allobank.finance.config.FrankfurterProperties;
+import io.netty.channel.ChannelOption;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebClientFactoryBean implements FactoryBean<WebClient> {
+
+    private final FrankfurterProperties properties;
+
+    @Override
+    public WebClient getObject() throws Exception {
+        log.info("Creating WebClient for base URL: {}", properties.getBaseUrl());
+
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofSeconds(180));
+
+        return WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/allobank/finance/config/AppProperties.java
+++ b/src/main/java/com/allobank/finance/config/AppProperties.java
@@ -1,0 +1,15 @@
+package com.allobank.finance.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+    private String githubUsername;
+    private List<String> validResourceTypes;
+}

--- a/src/main/java/com/allobank/finance/config/FetcherConfig.java
+++ b/src/main/java/com/allobank/finance/config/FetcherConfig.java
@@ -1,0 +1,23 @@
+package com.allobank.finance.config;
+
+import com.allobank.finance.fetcher.IDRDataFetcher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Configuration
+public class FetcherConfig {
+
+    @Bean
+    public Map<String, IDRDataFetcher> fetcherMap(List<IDRDataFetcher> fetchers) {
+        return fetchers.stream()
+                .collect(Collectors.toMap(
+                        IDRDataFetcher::getResourceType,
+                        Function.identity()
+                ));
+    }
+}

--- a/src/main/java/com/allobank/finance/config/FrankfurterProperties.java
+++ b/src/main/java/com/allobank/finance/config/FrankfurterProperties.java
@@ -1,0 +1,16 @@
+package com.allobank.finance.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "frankfurter")
+public class FrankfurterProperties {
+
+    private String baseUrl;
+    private int connectTimeoutMs = 5000;
+    private int readTimeoutMs = 10000;
+}

--- a/src/main/java/com/allobank/finance/config/OpenApiConfig.java
+++ b/src/main/java/com/allobank/finance/config/OpenApiConfig.java
@@ -1,0 +1,29 @@
+package com.allobank.finance.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Allo Bank Finance API")
+                        .version("v1")
+                        .description("""
+                            IDR Exchange Rate Aggregator.
+                            
+                            Data is fetched from Frankfurter API once at startup and served from an immutable in-memory store.
+                            
+                            **Spread Factor:** 0.00264 (GitHub username: thaufaniqbal)
+                            """)
+                        .contact(new Contact()
+                                .name("thaufaniqbal")
+                                .url("https://github.com/thaufaniqbal")));
+    }
+}

--- a/src/main/java/com/allobank/finance/controller/FinanceController.java
+++ b/src/main/java/com/allobank/finance/controller/FinanceController.java
@@ -1,0 +1,28 @@
+package com.allobank.finance.controller;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.service.FinanceDataService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/finance")
+@RequiredArgsConstructor
+public class FinanceController {
+
+    private final FinanceDataService financeDataService;
+
+    @GetMapping("/data/{resourceType}")
+    public ResponseEntity<FinanceDataResponse> getFinanceData(@PathVariable String resourceType) {
+
+        log.info("GET /api/v1/finance/data/{}", resourceType);
+        FinanceDataResponse response = financeDataService.getByResourceType(resourceType);
+        return ResponseEntity.ok((response));
+    }
+}

--- a/src/main/java/com/allobank/finance/dto/ApiResponse.java
+++ b/src/main/java/com/allobank/finance/dto/ApiResponse.java
@@ -1,0 +1,35 @@
+package com.allobank.finance.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String message;
+    private String timestamp;
+    private T data;
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message("OK")
+                .timestamp(Instant.now().toString())
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(message)
+                .timestamp(Instant.now().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/allobank/finance/dto/FinanceDataResponse.java
+++ b/src/main/java/com/allobank/finance/dto/FinanceDataResponse.java
@@ -1,0 +1,21 @@
+package com.allobank.finance.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FinanceDataResponse {
+
+    private String resourceType;
+    private String fetchedAt;
+    private Object data;
+
+    private Double usdBuySpreadIdr;
+    private Double spreadFactor;
+}

--- a/src/main/java/com/allobank/finance/dto/FrankfurterDto.java
+++ b/src/main/java/com/allobank/finance/dto/FrankfurterDto.java
@@ -1,0 +1,56 @@
+package com.allobank.finance.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class FrankfurterDto {
+
+    @Data
+    @NoArgsConstructor
+    public static class LatestRatesResponse {
+        private String amount;
+        private String base;
+        private String date;
+        private Map<String, BigDecimal> rates = new LinkedHashMap<>();
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonPropertyOrder({"amount", "base", "start_date", "end_date", "rates"})
+    public static class HistoricalRatesResponse {
+        private String amount;
+        private String base;
+
+        @JsonProperty("start_date")
+        private String startDate;
+
+        @JsonProperty("end_date")
+        private String endDate;
+
+        private Map<String, Map<String, BigDecimal>> rates = new LinkedHashMap<>();
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class CurrenciesResponse {
+        private Map<String, String> currencies = new LinkedHashMap<>();
+
+        @JsonAnySetter
+        public void addCurrency(String key, String value) {
+            this.currencies.put(key, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, String> getCurrencies() {
+            return currencies;
+        }
+    }
+}

--- a/src/main/java/com/allobank/finance/entity/FinanceDataCache.java
+++ b/src/main/java/com/allobank/finance/entity/FinanceDataCache.java
@@ -1,0 +1,31 @@
+package com.allobank.finance.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "finance_data_cache")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FinanceDataCache {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "resource_type", nullable = false, unique = true, length = 100)
+    private String resourceType;
+
+    @Column(name = "json_payload", nullable = false, columnDefinition = "TEXT")
+    private String jsonPayload;
+
+    @CreationTimestamp
+    @Column(name = "fetched_at", nullable = false, updatable = false)
+    private Instant fetchedAt;
+}

--- a/src/main/java/com/allobank/finance/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/allobank/finance/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.allobank.finance.exception;
+
+import com.allobank.finance.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleResourceNotFound(ResourceNotFoundException ex) {
+        log.warn("Resource not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFound(NoResourceFoundException ex) {
+        log.warn("No resource found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("Endpoint not found: " + ex.getMessage()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException ex) {
+        log.warn("Method not allowed: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(ApiResponse.error(ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalState(IllegalStateException ex) {
+        log.error("Illegal state: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("An unexpected error occurred: " + ex.getMessage()));
+    }
+}

--- a/src/main/java/com/allobank/finance/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/allobank/finance/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.allobank.finance.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/allobank/finance/fetcher/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/HistoricalIdrUsdFetcher.java
@@ -30,7 +30,7 @@ public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
                     .uri(HISTORICAL_URI)
                     .retrieve()
                     .bodyToMono(FrankfurterDto.HistoricalRatesResponse.class)
-                    .timeout(Duration.ofSeconds(60))
+                    .timeout(Duration.ofSeconds(180))
                     .block();
 
             if (response == null) {

--- a/src/main/java/com/allobank/finance/fetcher/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/HistoricalIdrUsdFetcher.java
@@ -1,0 +1,62 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.dto.FrankfurterDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "historical_idr_usd";
+    private static final String HISTORICAL_URI = "/2024-01-01..2024-01-05?from=IDR&to=USD";
+
+    private final WebClient webClient;
+
+    @Override
+    public FinanceDataResponse fetch() {
+        log.info("Fetching historical IDR/USD rates from Frankfurter API...");
+
+        try {
+            FrankfurterDto.HistoricalRatesResponse response = webClient.get()
+                    .uri(HISTORICAL_URI)
+                    .retrieve()
+                    .bodyToMono(FrankfurterDto.HistoricalRatesResponse.class)
+                    .timeout(Duration.ofSeconds(60))
+                    .block();
+
+            if (response == null) {
+                throw new IllegalStateException("Empty response from Frankfurter API for historical IDR/USD rates");
+            }
+
+            log.info("Historical IDR/USD rates fetched successfully. Date range: {} to {}",
+                    response.getStartDate(), response.getEndDate());
+
+            return FinanceDataResponse.builder()
+                    .resourceType(RESOURCE_TYPE)
+                    .fetchedAt(Instant.now().toString())
+                    .data(response)
+                    .build();
+
+        } catch (WebClientResponseException ex) {
+            log.error("HTTP error fetching historical IDR/USD rates: {} - {}", ex.getStatusCode(), ex.getResponseBodyAsString());
+            throw new RuntimeException("Failed to fetch historical IDR/USD rates: HTTP " + ex.getStatusCode(), ex);
+        } catch (Exception ex) {
+            log.error("Unexpected error fetching historical IDR/USD rates", ex);
+            throw new RuntimeException("Failed to fetch historical IDR/USD rates", ex);
+        }
+    }
+
+    @Override
+    public String getResourceType() {
+        return RESOURCE_TYPE;
+    }
+}

--- a/src/main/java/com/allobank/finance/fetcher/IDRDataFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/IDRDataFetcher.java
@@ -1,0 +1,11 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+
+
+public interface IDRDataFetcher {
+
+    FinanceDataResponse fetch();
+
+    String getResourceType();
+}

--- a/src/main/java/com/allobank/finance/fetcher/LatestIdrRatesFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/LatestIdrRatesFetcher.java
@@ -33,7 +33,7 @@ public class LatestIdrRatesFetcher implements IDRDataFetcher {
                     .uri("/latest?base=IDR")
                     .retrieve()
                     .bodyToMono(FrankfurterDto.LatestRatesResponse.class)
-                    .timeout(Duration.ofSeconds(60))
+                    .timeout(Duration.ofSeconds(180))
                     .block();
 
             if (response == null || response.getRates() == null) {

--- a/src/main/java/com/allobank/finance/fetcher/LatestIdrRatesFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/LatestIdrRatesFetcher.java
@@ -1,0 +1,80 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.dto.FrankfurterDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "latest_idr_rates";
+
+    private final WebClient webClient;
+    private final SpreadCalculator spreadCalculator;
+
+    @Override
+    public FinanceDataResponse fetch() {
+        log.info("Fetching latest IDR rates from Frankfurter API...");
+
+        try {
+            FrankfurterDto.LatestRatesResponse response = webClient.get()
+                    .uri("/latest?base=IDR")
+                    .retrieve()
+                    .bodyToMono(FrankfurterDto.LatestRatesResponse.class)
+                    .timeout(Duration.ofSeconds(60))
+                    .block();
+
+            if (response == null || response.getRates() == null) {
+                throw new IllegalStateException("Empty response from Frankfurter API for latest IDR rates");
+            }
+
+            BigDecimal rateUsd = response.getRates().get("USD");
+            if (rateUsd == null || rateUsd.compareTo(BigDecimal.ZERO) == 0) {
+                throw new IllegalStateException("USD rate not found or is zero in latest IDR rates response");
+            }
+
+            double usdBuySpreadIdr = spreadCalculator.calculateUsdBuySpreadIdr(rateUsd.doubleValue());
+
+            Map<String, Object> enrichedData = new LinkedHashMap<>();
+            enrichedData.put("amount", response.getAmount());
+            enrichedData.put("base", response.getBase());
+            enrichedData.put("date", response.getDate());
+            enrichedData.put("rates", response.getRates());
+
+            log.info("Latest IDR rates fetched successfully. USD rate: {}, USD_BuySpread_IDR: {}",
+                    rateUsd, usdBuySpreadIdr);
+
+            return FinanceDataResponse.builder()
+                    .resourceType(RESOURCE_TYPE)
+                    .fetchedAt(Instant.now().toString())
+                    .data(enrichedData)
+                    .usdBuySpreadIdr(usdBuySpreadIdr)
+                    .spreadFactor(spreadCalculator.getSpreadFactor())
+                    .build();
+
+        } catch (WebClientResponseException ex) {
+            log.error("HTTP error fetching latest IDR rates: {} - {}", ex.getStatusCode(), ex.getResponseBodyAsString());
+            throw new RuntimeException("Failed to fetch latest IDR rates: HTTP " + ex.getStatusCode(), ex);
+        } catch (Exception ex) {
+            log.error("Unexpected error fetching latest IDR rates", ex);
+            throw new RuntimeException("Failed to fetch latest IDR rates", ex);
+        }
+    }
+
+    @Override
+    public String getResourceType() {
+        return RESOURCE_TYPE;
+    }
+}

--- a/src/main/java/com/allobank/finance/fetcher/SpreadCalculator.java
+++ b/src/main/java/com/allobank/finance/fetcher/SpreadCalculator.java
@@ -1,0 +1,26 @@
+package com.allobank.finance.fetcher;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SpreadCalculator {
+
+    private final double spreadFactor;
+
+    public SpreadCalculator(@Value("${app.github-username}") String githubUsername) {
+        int sum = githubUsername.toLowerCase().chars().sum();
+        this.spreadFactor = (sum % 1000) / 100000.0;
+    }
+
+    public double getSpreadFactor() {
+        return spreadFactor;
+    }
+
+
+    public double calculateUsdBuySpreadIdr(double rateUsd) {
+        return (1.0 / rateUsd) * (1.0 + spreadFactor);
+    }
+}

--- a/src/main/java/com/allobank/finance/fetcher/SupportedCurrenciesFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/SupportedCurrenciesFetcher.java
@@ -1,0 +1,67 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "supported_currencies";
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public FinanceDataResponse fetch() {
+        log.info("Fetching supported currencies from Frankfurter API...");
+
+        try {
+            String rawJson = webClient.get()
+                    .uri("/currencies")
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofSeconds(60))
+                    .block();
+
+            if (rawJson == null || rawJson.isBlank()) {
+                throw new IllegalStateException("Empty response from Frankfurter API for supported currencies");
+            }
+
+            Map<String, String> currencies = objectMapper.readValue(
+                    rawJson, new TypeReference<Map<String, String>>() {}
+            );
+
+            log.info("Supported currencies fetched successfully. Total currencies: {}", currencies.size());
+
+            return FinanceDataResponse.builder()
+                    .resourceType(RESOURCE_TYPE)
+                    .fetchedAt(Instant.now().toString())
+                    .data(currencies)
+                    .build();
+
+        } catch (WebClientResponseException ex) {
+            log.error("HTTP error fetching supported currencies: {} - {}", ex.getStatusCode(), ex.getResponseBodyAsString());
+            throw new RuntimeException("Failed to fetch supported currencies: HTTP " + ex.getStatusCode(), ex);
+        } catch (Exception ex) {
+            log.error("Unexpected error fetching supported currencies", ex);
+            throw new RuntimeException("Failed to fetch supported currencies", ex);
+        }
+    }
+
+    @Override
+    public String getResourceType() {
+        return RESOURCE_TYPE;
+    }
+}

--- a/src/main/java/com/allobank/finance/fetcher/SupportedCurrenciesFetcher.java
+++ b/src/main/java/com/allobank/finance/fetcher/SupportedCurrenciesFetcher.java
@@ -32,7 +32,7 @@ public class SupportedCurrenciesFetcher implements IDRDataFetcher {
                     .uri("/currencies")
                     .retrieve()
                     .bodyToMono(String.class)
-                    .timeout(Duration.ofSeconds(60))
+                    .timeout(Duration.ofSeconds(180))
                     .block();
 
             if (rawJson == null || rawJson.isBlank()) {

--- a/src/main/java/com/allobank/finance/filter/MdcTraceFilter.java
+++ b/src/main/java/com/allobank/finance/filter/MdcTraceFilter.java
@@ -1,0 +1,41 @@
+package com.allobank.finance.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+
+@Component
+@Order(1)
+public class MdcTraceFilter implements Filter {
+
+    private static final String TRACE_ID_KEY = "traceId";
+    private static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String traceId = httpRequest.getHeader(TRACE_ID_HEADER);
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+        }
+
+        try {
+            MDC.put(TRACE_ID_KEY, traceId);
+            httpResponse.setHeader(TRACE_ID_HEADER, traceId);
+            chain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/src/main/java/com/allobank/finance/repository/FinanceDataCacheRepository.java
+++ b/src/main/java/com/allobank/finance/repository/FinanceDataCacheRepository.java
@@ -1,0 +1,12 @@
+package com.allobank.finance.repository;
+
+import com.allobank.finance.entity.FinanceDataCache;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FinanceDataCacheRepository extends JpaRepository<FinanceDataCache, Long> {
+    Optional<FinanceDataCache> findByResourceType(String resourceType);
+}

--- a/src/main/java/com/allobank/finance/runner/FinanceDataStartupRunner.java
+++ b/src/main/java/com/allobank/finance/runner/FinanceDataStartupRunner.java
@@ -1,0 +1,80 @@
+package com.allobank.finance.runner;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.entity.FinanceDataCache;
+import com.allobank.finance.fetcher.IDRDataFetcher;
+import com.allobank.finance.repository.FinanceDataCacheRepository;
+import com.allobank.finance.service.FinanceDataStore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class FinanceDataStartupRunner implements ApplicationRunner {
+
+    private final Map<String, IDRDataFetcher> fetcherMap;
+    private final FinanceDataStore financeDataStore;
+    private final FinanceDataCacheRepository cacheRepository;
+    private final ObjectMapper objectMapper;
+
+    public FinanceDataStartupRunner(
+            @Qualifier("fetcherMap") Map<String, IDRDataFetcher> fetcherMap,
+            FinanceDataStore financeDataStore,
+            FinanceDataCacheRepository cacheRepository,
+            ObjectMapper objectMapper) {
+        this.fetcherMap = fetcherMap;
+        this.financeDataStore = financeDataStore;
+        this.cacheRepository = cacheRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("=== Starting financial data initialization ===");
+        log.info("Fetching {} resource(s): {}", fetcherMap.size(), fetcherMap.keySet());
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (Map.Entry<String, IDRDataFetcher> entry : fetcherMap.entrySet()) {
+            String resourceType = entry.getKey();
+            IDRDataFetcher fetcher = entry.getValue();
+
+            try {
+                log.info("Fetching resource: {}", resourceType);
+                FinanceDataResponse response = fetcher.fetch();
+
+                financeDataStore.put(resourceType, response);
+
+                String jsonPayload = objectMapper.writeValueAsString(response);
+                FinanceDataCache cacheEntry = FinanceDataCache.builder()
+                        .resourceType(resourceType)
+                        .jsonPayload(jsonPayload)
+                        .build();
+                cacheRepository.save(cacheEntry);
+
+                log.info("Successfully loaded and persisted resource: {}", resourceType);
+                successCount++;
+
+            } catch (Exception e) {
+                log.error("Failed to fetch resource '{}': {}", resourceType, e.getMessage(), e);
+                failCount++;
+            }
+        }
+
+        financeDataStore.seal();
+
+        log.info("=== Financial data initialization complete: {}/{} resources loaded successfully ===",
+                successCount, fetcherMap.size());
+
+        if (failCount > 0) {
+            log.warn("{} resource(s) failed to load.", failCount);
+        }
+    }
+}

--- a/src/main/java/com/allobank/finance/service/FinanceDataService.java
+++ b/src/main/java/com/allobank/finance/service/FinanceDataService.java
@@ -1,5 +1,6 @@
 package com.allobank.finance.service;
 
+import com.allobank.finance.config.AppProperties;
 import com.allobank.finance.dto.FinanceDataResponse;
 import com.allobank.finance.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +13,17 @@ import org.springframework.stereotype.Service;
 public class FinanceDataService {
 
     private final FinanceDataStore financeDataStore;
+    private final AppProperties appProperties;
 
     public FinanceDataResponse getByResourceType(String resourceType) {
         log.debug("Serving request for resource type: {}", resourceType);
+
+        if (!appProperties.getValidResourceTypes().contains(resourceType)) {
+            throw new ResourceNotFoundException(
+                    "Resource type '" + resourceType + "' not found. " +
+                            "Valid types are: " + String.join(", ", appProperties.getValidResourceTypes())
+            );
+        }
 
         FinanceDataResponse response = financeDataStore.get(resourceType);
         if (response == null) {

--- a/src/main/java/com/allobank/finance/service/FinanceDataService.java
+++ b/src/main/java/com/allobank/finance/service/FinanceDataService.java
@@ -1,0 +1,29 @@
+package com.allobank.finance.service;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinanceDataService {
+
+    private final FinanceDataStore financeDataStore;
+
+    public FinanceDataResponse getByResourceType(String resourceType) {
+        log.debug("Serving request for resource type: {}", resourceType);
+
+        FinanceDataResponse response = financeDataStore.get(resourceType);
+        if (response == null) {
+            throw new ResourceNotFoundException(
+                    "Resource type '" + resourceType + "' is valid but data is not available. " +
+                            "Please try again later."
+            );
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/allobank/finance/service/FinanceDataStore.java
+++ b/src/main/java/com/allobank/finance/service/FinanceDataStore.java
@@ -1,0 +1,51 @@
+package com.allobank.finance.service;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+@Slf4j
+@Component
+public class FinanceDataStore {
+
+    private final ConcurrentHashMap<String, FinanceDataResponse> store = new ConcurrentHashMap<>();
+    private final AtomicBoolean sealed = new AtomicBoolean(false);
+
+    public void put(String resourceType, FinanceDataResponse response) {
+        if (sealed.get()) {
+            throw new IllegalStateException(
+                "FinanceDataStore is sealed. No writes allowed after application startup.");
+        }
+        store.put(resourceType, response);
+        log.debug("Stored data for resource type: {}", resourceType);
+    }
+
+    public void seal() {
+        if (sealed.compareAndSet(false, true)) {
+            log.info("FinanceDataStore sealed. {} resource(s) loaded: {}",
+                    store.size(), store.keySet());
+        }
+    }
+
+    public FinanceDataResponse get(String resourceType) {
+        return store.get(resourceType);
+    }
+
+    public Map<String, FinanceDataResponse> getAll() {
+        return Collections.unmodifiableMap(store);
+    }
+
+    public boolean isSealed() {
+        return sealed.get();
+    }
+
+    public boolean containsKey(String resourceType) {
+        return store.containsKey(resourceType);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=allo-bank-finance
+server.port=8099

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,6 @@ management.info.env.enabled=true
 
 spring.jackson.generator.write-numbers-as-strings=false
 spring.jackson.serialization.write-bigdecimal-as-plain=true
+
+# Valid resource types
+app.valid-resource-types=latest_idr_rates,historical_idr_usd,supported_currencies

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,37 @@
 spring.application.name=allo-bank-finance
 server.port=8099
+
+## DB Config
+spring.datasource.url=jdbc:h2:mem:allobank;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+
+## Logging Config
+logging.level.com.allobank.finance=INFO
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%thread] [%X{traceId}] %-5level %logger{36} - %msg%n
+
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false
+
+
+frankfurter.base-url=https://api.frankfurter.app
+frankfurter.connect-timeout-ms=5000
+frankfurter.read-timeout-ms=10000
+
+app.github-username=thaufaniqbal
+
+management.endpoints.web.exposure.include=health,info
+management.endpoints.web.base-path=/actuator
+management.endpoint.health.show-details=always
+management.info.env.enabled=true
+
+spring.jackson.generator.write-numbers-as-strings=false
+spring.jackson.serialization.write-bigdecimal-as-plain=true

--- a/src/test/java/com/allobank/finance/controller/FinanceControllerTest.java
+++ b/src/test/java/com/allobank/finance/controller/FinanceControllerTest.java
@@ -1,0 +1,97 @@
+package com.allobank.finance.controller;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.exception.ResourceNotFoundException;
+import com.allobank.finance.service.FinanceDataService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(FinanceController.class)
+class FinanceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FinanceDataService financeDataService;
+
+    @Test
+    void getFinanceData_latestIdrRates_shouldReturn200() throws Exception {
+        FinanceDataResponse mockResponse = FinanceDataResponse.builder()
+                .resourceType("latest_idr_rates")
+                .fetchedAt("2024-01-05T08:00:00Z")
+                .data(Map.of("USD", 0.000064))
+                .usdBuySpreadIdr(15666.75)
+                .spreadFactor(0.00264)
+                .build();
+
+        when(financeDataService.getByResourceType("latest_idr_rates")).thenReturn(mockResponse);
+
+        mockMvc.perform(get("/api/finance/data/latest_idr_rates")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resourceType").value("latest_idr_rates"))
+                .andExpect(jsonPath("$.usdBuySpreadIdr").value(15666.75))
+                .andExpect(jsonPath("$.spreadFactor").value(0.00264));
+    }
+
+    @Test
+    void getFinanceData_invalidResourceType_shouldReturn404() throws Exception {
+        when(financeDataService.getByResourceType("invalid_type"))
+                .thenThrow(new ResourceNotFoundException("Resource type 'invalid_type' not found"));
+
+        mockMvc.perform(get("/api/finance/data/invalid_type")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getFinanceData_historicalIdrUsd_shouldReturn200() throws Exception {
+        FinanceDataResponse mockResponse = FinanceDataResponse.builder()
+                .resourceType("historical_idr_usd")
+                .fetchedAt("2024-01-05T08:00:00Z")
+                .data(Map.of("2024-01-02", Map.of("USD", 0.000064)))
+                .build();
+
+        when(financeDataService.getByResourceType("historical_idr_usd")).thenReturn(mockResponse);
+
+        mockMvc.perform(get("/api/finance/data/historical_idr_usd")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resourceType").value("historical_idr_usd"))
+                .andExpect(jsonPath("$.usdBuySpreadIdr").doesNotExist());
+    }
+
+    @Test
+    void getFinanceData_supportedCurrencies_shouldReturn200() throws Exception {
+        FinanceDataResponse mockResponse = FinanceDataResponse.builder()
+                .resourceType("supported_currencies")
+                .fetchedAt("2024-01-05T08:00:00Z")
+                .data(Map.of("IDR", "Indonesian Rupiah", "USD", "US Dollar"))
+                .build();
+
+        when(financeDataService.getByResourceType("supported_currencies")).thenReturn(mockResponse);
+
+        mockMvc.perform(get("/api/finance/data/supported_currencies")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resourceType").value("supported_currencies"));
+    }
+
+    @Test
+    void getFinanceData_withPostMethod_shouldReturn405() throws Exception {
+        mockMvc.perform(post("/api/finance/data/latest_idr_rates")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isMethodNotAllowed());
+    }
+}

--- a/src/test/java/com/allobank/finance/fetcher/HistoricalIdrUsdFetcherTest.java
+++ b/src/test/java/com/allobank/finance/fetcher/HistoricalIdrUsdFetcherTest.java
@@ -1,0 +1,95 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.dto.FrankfurterDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HistoricalIdrUsdFetcherTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private HistoricalIdrUsdFetcher fetcher;
+
+    @BeforeEach
+    void setUp() {
+        fetcher = new HistoricalIdrUsdFetcher(webClient);
+    }
+
+    @Test
+    void fetch_shouldReturnHistoricalRates() {
+        // Arrange
+        FrankfurterDto.HistoricalRatesResponse mockResponse = new FrankfurterDto.HistoricalRatesResponse();
+        mockResponse.setBase("IDR");
+        mockResponse.setStartDate("2024-01-01");
+        mockResponse.setEndDate("2024-01-05");
+        mockResponse.setRates(Map.of(
+                "2024-01-02", Map.of("USD", BigDecimal.valueOf(0.000064)),
+                "2024-01-03", Map.of("USD", BigDecimal.valueOf(0.000065)),
+                "2024-01-05", Map.of("USD", BigDecimal.valueOf(0.000063))
+        ));
+
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(FrankfurterDto.HistoricalRatesResponse.class))
+                .thenReturn(Mono.just(mockResponse));
+
+        // Act
+        FinanceDataResponse result = fetcher.fetch();
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceType()).isEqualTo("historical_idr_usd");
+        assertThat(result.getData()).isInstanceOf(FrankfurterDto.HistoricalRatesResponse.class);
+        assertThat(result.getUsdBuySpreadIdr()).isNull(); // no spread for historical
+        assertThat(result.getFetchedAt()).isNotNull();
+
+        FrankfurterDto.HistoricalRatesResponse data =
+                (FrankfurterDto.HistoricalRatesResponse) result.getData();
+        assertThat(data.getStartDate()).isEqualTo("2024-01-01");
+        assertThat(data.getEndDate()).isEqualTo("2024-01-05");
+        assertThat(data.getRates()).hasSize(3);
+    }
+
+    @Test
+    void fetch_shouldThrowWhenApiReturnsNull() {
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(FrankfurterDto.HistoricalRatesResponse.class))
+                .thenReturn(Mono.empty());
+
+        assertThatThrownBy(() -> fetcher.fetch())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to fetch historical IDR/USD rates");
+    }
+
+    @Test
+    void getResourceType_shouldReturnCorrectKey() {
+        assertThat(fetcher.getResourceType()).isEqualTo("historical_idr_usd");
+    }
+}

--- a/src/test/java/com/allobank/finance/fetcher/LatestIdrRatesFetcherTest.java
+++ b/src/test/java/com/allobank/finance/fetcher/LatestIdrRatesFetcherTest.java
@@ -1,0 +1,110 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.dto.FrankfurterDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LatestIdrRatesFetcherTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private SpreadCalculator spreadCalculator;
+    private LatestIdrRatesFetcher fetcher;
+
+    @BeforeEach
+    void setUp() {
+        // username "thaufaniqbal" → sum=1264 → factor=0.00264
+        spreadCalculator = new SpreadCalculator("thaufaniqbal");
+        fetcher = new LatestIdrRatesFetcher(webClient, spreadCalculator);
+    }
+
+    @Test
+    void fetch_shouldReturnLatestIdrRatesWithSpread() {
+        // Arrange
+        FrankfurterDto.LatestRatesResponse mockResponse = new FrankfurterDto.LatestRatesResponse();
+        mockResponse.setAmount("1");
+        mockResponse.setBase("IDR");
+        mockResponse.setDate("2024-01-05");
+        mockResponse.setRates(Map.of("USD", BigDecimal.valueOf(0.000064), "EUR", BigDecimal.valueOf(0.000059)));
+
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(FrankfurterDto.LatestRatesResponse.class))
+                .thenReturn(Mono.just(mockResponse));
+
+        // Act
+        FinanceDataResponse result = fetcher.fetch();
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceType()).isEqualTo("latest_idr_rates");
+        assertThat(result.getData()).isNotNull();
+        assertThat(result.getUsdBuySpreadIdr()).isNotNull();
+        assertThat(result.getSpreadFactor()).isEqualTo(0.00264);
+        assertThat(result.getFetchedAt()).isNotNull();
+
+        // Verify spread calculation: (1 / 0.000064) * (1 + 0.00264) = 15666.75
+        double expectedSpread = (1.0 / 0.000064) * (1.0 + 0.00264);
+        assertThat(result.getUsdBuySpreadIdr()).isCloseTo(expectedSpread, within(0.01));
+    }
+
+    @Test
+    void fetch_shouldThrowWhenApiReturnsNull() {
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(FrankfurterDto.LatestRatesResponse.class))
+                .thenReturn(Mono.empty());
+
+        assertThatThrownBy(() -> fetcher.fetch())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to fetch latest IDR rates");
+    }
+
+    @Test
+    void fetch_shouldThrowWhenUsdRateIsMissing() {
+        FrankfurterDto.LatestRatesResponse mockResponse = new FrankfurterDto.LatestRatesResponse();
+        mockResponse.setBase("IDR");
+        mockResponse.setRates(Map.of("EUR", BigDecimal.valueOf(0.000059))); // no USD
+
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(FrankfurterDto.LatestRatesResponse.class))
+                .thenReturn(Mono.just(mockResponse));
+
+        assertThatThrownBy(() -> fetcher.fetch())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to fetch latest IDR rates");
+    }
+
+    @Test
+    void getResourceType_shouldReturnCorrectKey() {
+        assertThat(fetcher.getResourceType()).isEqualTo("latest_idr_rates");
+    }
+}

--- a/src/test/java/com/allobank/finance/fetcher/SpreadCalculatorTest.java
+++ b/src/test/java/com/allobank/finance/fetcher/SpreadCalculatorTest.java
@@ -1,0 +1,41 @@
+package com.allobank.finance.fetcher;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class SpreadCalculatorTest {
+
+    @Test
+    void shouldCalculateCorrectSpreadForThaufaniqbal() {
+        SpreadCalculator calculator = new SpreadCalculator("thaufaniqbal");
+
+        assertThat(calculator.getSpreadFactor()).isEqualTo(0.00264);
+    }
+
+    @Test
+    void shouldCalculateUsdBuySpreadIdrCorrectly() {
+        SpreadCalculator calculator = new SpreadCalculator("thaufaniqbal");
+        double rateUsd = 0.000064;
+
+        double result = calculator.calculateUsdBuySpreadIdr(rateUsd);
+
+        double expected = (1.0 / rateUsd) * (1.0 + 0.00264);
+        assertThat(result).isCloseTo(expected, within(0.0001));
+    }
+
+    @Test
+    void shouldHandleDifferentUsername() {
+
+        SpreadCalculator calculator = new SpreadCalculator("johndoe47");
+        assertThat(calculator.getSpreadFactor()).isEqualTo(0.00850);
+    }
+
+    @Test
+    void shouldBeCaseInsensitive() {
+        SpreadCalculator lower = new SpreadCalculator("thaufaniqbal");
+        SpreadCalculator upper = new SpreadCalculator("THAUFANIQBAL");
+
+        assertThat(lower.getSpreadFactor()).isEqualTo(upper.getSpreadFactor());
+    }
+}

--- a/src/test/java/com/allobank/finance/fetcher/SupportedCurrenciesFetcherTest.java
+++ b/src/test/java/com/allobank/finance/fetcher/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,93 @@
+package com.allobank.finance.fetcher;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SupportedCurrenciesFetcherTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    private SupportedCurrenciesFetcher fetcher;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        fetcher = new SupportedCurrenciesFetcher(webClient, objectMapper);
+    }
+
+    @Test
+    void fetch_shouldReturnCurrenciesMap() throws Exception {
+        // Arrange
+        String mockJson = """
+                {
+                  "AUD": "Australian Dollar",
+                  "IDR": "Indonesian Rupiah",
+                  "USD": "US Dollar",
+                  "EUR": "Euro"
+                }
+                """;
+
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(String.class)).thenReturn(Mono.just(mockJson));
+
+        // Act
+        FinanceDataResponse result = fetcher.fetch();
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceType()).isEqualTo("supported_currencies");
+        assertThat(result.getUsdBuySpreadIdr()).isNull(); // no spread for currencies
+        assertThat(result.getFetchedAt()).isNotNull();
+        assertThat(result.getData()).isInstanceOf(Map.class);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> currencies = (Map<String, String>) result.getData();
+        assertThat(currencies).hasSize(4);
+        assertThat(currencies).containsEntry("IDR", "Indonesian Rupiah");
+        assertThat(currencies).containsEntry("USD", "US Dollar");
+    }
+
+    @Test
+    void fetch_shouldThrowWhenApiReturnsBlank() {
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(String.class)).thenReturn(Mono.just(""));
+
+        assertThatThrownBy(() -> fetcher.fetch())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to fetch supported currencies");
+    }
+
+    @Test
+    void getResourceType_shouldReturnCorrectKey() {
+        assertThat(fetcher.getResourceType()).isEqualTo("supported_currencies");
+    }
+}

--- a/src/test/java/com/allobank/finance/integration/FinanceDataStartupRunnerIntegrationTest.java
+++ b/src/test/java/com/allobank/finance/integration/FinanceDataStartupRunnerIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.allobank.finance.integration;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.repository.FinanceDataCacheRepository;
+import com.allobank.finance.service.FinanceDataStore;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class FinanceDataStartupRunnerIntegrationTest {
+
+    static WireMockServer wireMockServer;
+
+    @Autowired
+    private FinanceDataStore financeDataStore;
+
+    @Autowired
+    private FinanceDataCacheRepository cacheRepository;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+
+        wireMockServer.stubFor(get(urlEqualTo("/latest?base=IDR"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "amount": 1.0,
+                              "base": "IDR",
+                              "date": "2024-01-05",
+                              "rates": {
+                                "USD": 0.000064,
+                                "EUR": 0.000059,
+                                "SGD": 0.000086
+                              }
+                            }
+                            """)));
+
+        wireMockServer.stubFor(get(urlEqualTo("/2024-01-01..2024-01-05?from=IDR&to=USD"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "amount": 1.0,
+                              "base": "IDR",
+                              "start_date": "2024-01-01",
+                              "end_date": "2024-01-05",
+                              "rates": {
+                                "2024-01-02": { "USD": 0.000064 },
+                                "2024-01-03": { "USD": 0.000065 },
+                                "2024-01-05": { "USD": 0.000063 }
+                              }
+                            }
+                            """)));
+
+        wireMockServer.stubFor(get(urlEqualTo("/currencies"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "AUD": "Australian Dollar",
+                              "EUR": "Euro",
+                              "IDR": "Indonesian Rupiah",
+                              "SGD": "Singapore Dollar",
+                              "USD": "US Dollar"
+                            }
+                            """)));
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        if (wireMockServer != null) wireMockServer.stop();
+    }
+
+    @DynamicPropertySource
+    static void overrideFrankfurterBaseUrl(DynamicPropertyRegistry registry) {
+        registry.add("frankfurter.base-url", () -> "http://localhost:" + wireMockServer.port());
+    }
+
+    @Test
+    void contextLoads_andStoreIsSealed() {
+        assertThat(financeDataStore.isSealed()).isTrue();
+    }
+
+    @Test
+    void allThreeResourceTypes_shouldBeLoadedOnStartup() {
+        assertThat(financeDataStore.containsKey("latest_idr_rates"))
+                .as("latest_idr_rates should be loaded").isTrue();
+        assertThat(financeDataStore.containsKey("historical_idr_usd"))
+                .as("historical_idr_usd should be loaded").isTrue();
+        assertThat(financeDataStore.containsKey("supported_currencies"))
+                .as("supported_currencies should be loaded").isTrue();
+    }
+
+    @Test
+    void latestIdrRates_shouldContainSpreadCalculation() {
+        FinanceDataResponse latestRates = financeDataStore.get("latest_idr_rates");
+
+        assertThat(latestRates).isNotNull();
+        assertThat(latestRates.getUsdBuySpreadIdr())
+                .as("USD_BuySpread_IDR should be calculated")
+                .isNotNull()
+                .isPositive();
+        assertThat(latestRates.getSpreadFactor())
+                .as("Spread factor should be 0.00264 for 'thaufaniqbal'")
+                .isEqualTo(0.00264);
+
+        double expected = (1.0 / 0.000064) * (1.0 + 0.00264);
+        assertThat(latestRates.getUsdBuySpreadIdr())
+                .isCloseTo(expected, within(0.01));
+    }
+
+    @Test
+    void historicalIdrUsd_shouldNotContainSpread() {
+        FinanceDataResponse historical = financeDataStore.get("historical_idr_usd");
+        assertThat(historical).isNotNull();
+        assertThat(historical.getUsdBuySpreadIdr()).isNull();
+    }
+
+    @Test
+    void supportedCurrencies_shouldBeNonEmptyMap() {
+        FinanceDataResponse currencies = financeDataStore.get("supported_currencies");
+        assertThat(currencies).isNotNull();
+        assertThat(currencies.getUsdBuySpreadIdr()).isNull();
+        assertThat(currencies.getData()).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, String> data = (Map<String, String>) currencies.getData();
+        assertThat(data).containsKey("IDR").containsKey("USD");
+    }
+
+    @Test
+    void allThreeResources_shouldBePersistedToDatabase() {
+        assertThat(cacheRepository.findByResourceType("latest_idr_rates")).isPresent();
+        assertThat(cacheRepository.findByResourceType("historical_idr_usd")).isPresent();
+        assertThat(cacheRepository.findByResourceType("supported_currencies")).isPresent();
+    }
+
+    @Test
+    void sealedStore_shouldRejectNewWrites() {
+        assertThat(financeDataStore.isSealed()).isTrue();
+        assertThatThrownBy(() ->
+                financeDataStore.put("test_resource",
+                        FinanceDataResponse.builder().resourceType("test").build()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("sealed");
+    }
+
+    @Test
+    void wireMock_shouldHaveBeenCalledForAllThreeEndpoints() {
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/latest?base=IDR")));
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/2024-01-01..2024-01-05?from=IDR&to=USD")));
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/currencies")));
+    }
+}

--- a/src/test/java/com/allobank/finance/service/FinanceDataServiceTest.java
+++ b/src/test/java/com/allobank/finance/service/FinanceDataServiceTest.java
@@ -6,6 +6,8 @@ import com.allobank.finance.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -15,12 +17,14 @@ class FinanceDataServiceTest {
     private FinanceDataService financeDataService;
     private AppProperties appProperties;
 
-
     @BeforeEach
     void setUp() {
         financeDataStore = new FinanceDataStore();
         appProperties = new AppProperties();
-        financeDataService = new FinanceDataService (financeDataStore, appProperties);
+        appProperties.setValidResourceTypes(
+                List.of("latest_idr_rates", "historical_idr_usd", "supported_currencies")
+        );
+        financeDataService = new FinanceDataService(financeDataStore, appProperties);
     }
 
     @Test
@@ -29,7 +33,6 @@ class FinanceDataServiceTest {
                 .resourceType("latest_idr_rates")
                 .fetchedAt("2024-01-05T08:00:00Z")
                 .build();
-
         financeDataStore.put("latest_idr_rates", response);
 
         FinanceDataResponse result = financeDataService.getByResourceType("latest_idr_rates");

--- a/src/test/java/com/allobank/finance/service/FinanceDataServiceTest.java
+++ b/src/test/java/com/allobank/finance/service/FinanceDataServiceTest.java
@@ -1,21 +1,26 @@
 package com.allobank.finance.service;
 
+import com.allobank.finance.config.AppProperties;
 import com.allobank.finance.dto.FinanceDataResponse;
 import com.allobank.finance.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FinanceDataServiceTest {
 
     private FinanceDataStore financeDataStore;
     private FinanceDataService financeDataService;
+    private AppProperties appProperties;
+
 
     @BeforeEach
     void setUp() {
         financeDataStore = new FinanceDataStore();
-        financeDataService = new FinanceDataService(financeDataStore);
+        appProperties = new AppProperties();
+        financeDataService = new FinanceDataService (financeDataStore, appProperties);
     }
 
     @Test

--- a/src/test/java/com/allobank/finance/service/FinanceDataServiceTest.java
+++ b/src/test/java/com/allobank/finance/service/FinanceDataServiceTest.java
@@ -1,0 +1,42 @@
+package com.allobank.finance.service;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import com.allobank.finance.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class FinanceDataServiceTest {
+
+    private FinanceDataStore financeDataStore;
+    private FinanceDataService financeDataService;
+
+    @BeforeEach
+    void setUp() {
+        financeDataStore = new FinanceDataStore();
+        financeDataService = new FinanceDataService(financeDataStore);
+    }
+
+    @Test
+    void getByResourceType_shouldReturnStoredData() {
+        FinanceDataResponse response = FinanceDataResponse.builder()
+                .resourceType("latest_idr_rates")
+                .fetchedAt("2024-01-05T08:00:00Z")
+                .build();
+
+        financeDataStore.put("latest_idr_rates", response);
+
+        FinanceDataResponse result = financeDataService.getByResourceType("latest_idr_rates");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResourceType()).isEqualTo("latest_idr_rates");
+    }
+
+    @Test
+    void getByResourceType_unknownKey_shouldThrowResourceNotFoundException() {
+        assertThatThrownBy(() -> financeDataService.getByResourceType("unknown"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("unknown");
+    }
+}

--- a/src/test/java/com/allobank/finance/service/FinanceDataStoreTest.java
+++ b/src/test/java/com/allobank/finance/service/FinanceDataStoreTest.java
@@ -1,0 +1,85 @@
+package com.allobank.finance.service;
+
+import com.allobank.finance.dto.FinanceDataResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+class FinanceDataStoreTest {
+
+    private FinanceDataStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new FinanceDataStore();
+    }
+
+    @Test
+    void put_andGet_shouldWorkBeforeSealing() {
+        FinanceDataResponse response = FinanceDataResponse.builder()
+                .resourceType("latest_idr_rates").build();
+
+        store.put("latest_idr_rates", response);
+
+        assertThat(store.get("latest_idr_rates")).isEqualTo(response);
+    }
+
+    @Test
+    void seal_shouldPreventFurtherWrites() {
+        store.seal();
+
+        assertThatThrownBy(() -> store.put("any_key",
+                FinanceDataResponse.builder().resourceType("any").build()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("sealed");
+    }
+
+    @Test
+    void isSealed_shouldBeFalseByDefault() {
+        assertThat(store.isSealed()).isFalse();
+    }
+
+    @Test
+    void seal_shouldBeIdempotent() {
+        store.seal();
+        store.seal();
+        assertThat(store.isSealed()).isTrue();
+    }
+
+    @Test
+    void getAll_shouldReturnUnmodifiableMap() {
+        store.put("latest_idr_rates", FinanceDataResponse.builder()
+                .resourceType("latest_idr_rates").build());
+        store.seal();
+
+        assertThatThrownBy(() -> store.getAll().put("new_key", null))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void concurrentReads_shouldBeSafeAfterSealing() throws InterruptedException {
+        store.put("latest_idr_rates", FinanceDataResponse.builder()
+                .resourceType("latest_idr_rates").build());
+        store.seal();
+
+        int threadCount = 50;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Future<FinanceDataResponse>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> store.get("latest_idr_rates")));
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+
+        for (Future<FinanceDataResponse> future : futures) {
+            assertThatCode(future::get).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+frankfurter:
+  base-url: http://localhost:9999
+  connect-timeout-ms: 10000
+  read-timeout-ms: 15000
+
+app:
+  github-username: thaufaniqbal
+
+logging:
+  level:
+    com.allobank.finance: DEBUG


### PR DESCRIPTION
## Summary
This PR implements the Strategy Pattern for IDR-related data fetchers and sets up the main service with spread factor calculation. It ensures modularity, testability, and clean architecture for the Finance API.

## Changes
- Added strategy classes:
  - LatestIdrRatesFetcher (with spread factor calculation)
  - HistoricalIdrUsdFetcher
  - SupportedCurrenciesFetcher
- Configured WebClient via FactoryBean with base URL and timeout
- Implemented USD_BuySpread_IDR calculation using personalized spread factor (0.00264)
- Built FinanceDataStore as a thread-safe immutable in-memory store
- Added ApplicationRunner for startup data initialization
- Implemented MDC Trace Filter for request tracing
- Added exception handling with custom ResourceNotFoundException
- Updated README with setup, usage examples, and endpoint documentation
- Added unit and integration tests (JUnit 5, Mockito, WireMock)

## Testing
- Verified endpoints via cURL/Postman:
  - `/api/finance/data/latest_idr_rates`
  - `/api/finance/data/historical_idr_usd`
  - `/api/finance/data/supported_currencies`
- Spread factor calculation matches requirements
- All unit and integration tests passed (`mvn test`)

## Notes
- Health check and app info available via Spring Boot Actuator
- H2 in-memory database console enabled for inspection
- Code structured to be modular, maintainable, and easily extensible for new resource types