### PR TITLE
feat: implement IDR rate aggregator strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Logs ###
+logs/
+*.log
+*.log.gz

--- a/README.md
+++ b/README.md
@@ -1,139 +1,296 @@
-# Allo Bank Backend Developer Take-Home Test
+# Finance API – Allo Bank Take-Home Test
 
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
+> **Oleh:** Andry Ramadhan
+> **Role:** Backend Developer Candidate
 
-## 📝 Objective
+---
 
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
+## 📋 Deskripsi Proyek
 
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
+REST API berbasis Spring Boot yang mengagregasi data nilai tukar Rupiah Indonesia (IDR) dari [Frankfurter Exchange Rate API](https://api.frankfurter.app/) publik. Seluruh data diambil **sekali saat startup** dan disimpan di **in-memory store yang thread-safe dan immutable**, sehingga setiap request HTTP dilayani dari cache — tanpa panggilan eksternal per request.
 
-## I. Core Task: The Polymorphic API
+---
 
-### 1. External API Integration (Frankfurter API)
+## 🔧 Prasyarat
 
-* **Base URL (Public):** `https://api.frankfurter.app/`.
+| Tool     | Versi Minimum                                              |
+| -------- | ---------------------------------------------------------- |
+| Java     | 21                                                         |
+| Maven    | 3.9+                                                       |
+| Internet | Diperlukan saat startup (untuk fetch data Frankfurter API) |
 
-* You must integrate with three distinct data resources to enforce the architectural pattern:
+---
 
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
+## 🚀 Cara Menjalankan
 
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
+### 1. Clone & Masuk ke Direktori
 
-   3.  `/currencies` (The list of all supported currency symbols)
+```bash
+git clone <url-repository>
+cd finance
+```
 
-### 2. Internal API Endpoint
+### 2. Build Proyek
 
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
+```bash
+./mvnw clean package -DskipTests
+```
+
+### 3. Jalankan Aplikasi
 
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
+```bash
+./mvnw spring-boot:run
+```
 
-### 3. Required Functionality & Business Logic
+Atau dengan JAR yang sudah dibuild:
 
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
+```bash
+java -jar target/finance-0.0.1-SNAPSHOT.jar
+```
 
-* **Data Load:** All three resources should be fetched from the external API.
+Aplikasi akan berjalan di **http://localhost:8080**.
 
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
-
-  **The Spread Factor Must Be Unique :**
-
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
-
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
-
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
-
-## II. Architectural Constraints
-
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
-
-### Constraint A: The Strategy Pattern
-
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
-
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
-
-2.  Implement **three concrete strategy classes** (one for each resource).
-
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
-
-### Constraint B: Client Factory Bean
-
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
-
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
-
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
-
-### Constraint C: Startup Data Runner & Immutability
-
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
-
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
-
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
-
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
-
-## III. Production Readiness & Deliverables
-
-Your final solution must demonstrate production quality through code, testing, and communication.
-
-### 1. Robustness & Best Practices
-
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
-
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
-
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
-
-### 2. Testing
-
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
-
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
-
-### 3. Documentation
-
-A clear `README.md` is mandatory. It must include:
-
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
-
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
-
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
-
-* ---
-
-* ### 🛠️ Architectural Rationale
-
-  This section should contain a brief, but detailed, explanation answering the following questions:
-
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
-
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
-
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
-
-## IV. Submission & Review Process
-
-1.  **Fork** this repository.
-
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
-
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
-4.  Please complete the form to submit your technical test: [Click Here](https://forms.gle/nZKQ2EjTCPfAKHog7)
-
-**Your PR will be evaluated on the following:**
-
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
-
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
-
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
-
-Good luck!
+Saat startup, Anda akan melihat log seperti:
+
+```
+=== DataIngestionRunner: Memulai inisialisasi data dari Frankfurter API ===
+=== DataIngestionRunner: Data berhasil dimuat dalam XXX ms ===
+```
+
+### 4. Jalankan Tests
+
+```bash
+# Unit tests saja (tanpa koneksi internet)
+./mvnw test -Dgroups=unit
+
+# Semua test (termasuk integration test, membutuhkan internet)
+./mvnw test
+```
+
+---
+
+## 📡 Penggunaan Endpoint
+
+**Base URL:** `http://localhost:8080`
+
+### 1. Kurs IDR Terbaru (dengan Spread Perbankan)
+
+```bash
+curl -s http://localhost:8080/api/finance/data/latest_idr_rates | jq .
+```
+
+**Contoh Respons:**
+
+```json
+{
+  "status": "success",
+  "message": "Data berhasil diambil",
+  "data": [
+    {
+      "resourceType": "latest_idr_rates",
+      "data": {
+        "amount": 1.0,
+        "base": "IDR",
+        "date": "2025-02-25",
+        "rates": {
+          "USD": 0.000062,
+          "EUR": 0.000058,
+          "...": "..."
+        },
+        "USD_BuySpread_IDR": 16138.23
+      }
+    }
+  ]
+}
+```
+
+### 2. Data Historis IDR → USD (2024-01-01 s.d. 2024-01-05)
+
+```bash
+curl -s http://localhost:8080/api/finance/data/historical_idr_usd | jq .
+```
+
+**Contoh Respons:**
+
+```json
+{
+  "status": "success",
+  "message": "Data berhasil diambil",
+  "data": [
+    {
+      "resourceType": "historical_idr_usd",
+      "data": {
+        "amount": 1.0,
+        "base": "IDR",
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-05",
+        "rates": {
+          "2024-01-02": { "USD": 0.000064 },
+          "2024-01-03": { "USD": 0.000064 },
+          "2024-01-04": { "USD": 0.000065 },
+          "2024-01-05": { "USD": 0.000064 }
+        }
+      }
+    }
+  ]
+}
+```
+
+### 3. Daftar Mata Uang yang Didukung
+
+```bash
+curl -s http://localhost:8080/api/finance/data/supported_currencies | jq .
+```
+
+**Contoh Respons:**
+
+```json
+{
+  "status": "success",
+  "message": "Data berhasil diambil",
+  "data": [
+    {
+      "resourceType": "supported_currencies",
+      "data": {
+        "AUD": "Australian Dollar",
+        "EUR": "Euro",
+        "IDR": "Indonesian Rupiah",
+        "USD": "US Dollar",
+        "...": "..."
+      }
+    }
+  ]
+}
+```
+
+### 4. Resource Type Tidak Dikenal (404)
+
+```bash
+curl -s http://localhost:8080/api/finance/data/unknown | jq .
+```
+
+```json
+{
+  "status": "error",
+  "httpCode": 404,
+  "message": "Resource type tidak ditemukan: 'unknown'. Nilai yang valid: latest_idr_rates, historical_idr_usd, supported_currencies"
+}
+```
+
+---
+
+## 🔢 Personalisasi: GitHub Username & Spread Factor
+
+| Item                     | Nilai                                        |
+| ------------------------ | -------------------------------------------- |
+| **GitHub Username**      | `ramandry12`                                 |
+| **Karakter (lowercase)** | `r a m a n d r y 1 2`                        |
+| **Nilai Unicode**        | 114+97+109+97+110+100+114+121+49+50          |
+| **Total Unicode Sum**    | **961**                                      |
+| **Kalkulasi**            | `(961 % 1000) / 100000.0` = `961 / 100000.0` |
+| **Spread Factor**        | **0.00961**                                  |
+
+**Formula USD_BuySpread_IDR:**
+
+```
+USD_BuySpread_IDR = (1 / Rate_USD) * (1 + 0.00961)
+```
+
+Contoh jika `Rate_USD = 0.000064` (IDR/USD dari API):
+
+```
+= (1 / 0.000064) * 1.00961
+= 15625.0 * 1.00961
+= 15775.16
+```
+
+---
+
+## 🏛️ Alasan Arsitektur (Architectural Rationale)
+
+### 1. Polymorphism Justification – Strategy Pattern
+
+**Mengapa Strategy Pattern, bukan conditional block?**
+
+Strategy Pattern digunakan untuk memisahkan _logika penanganan setiap resource type_ ke dalam kelas-kelas terpisah yang memiliki tanggung jawab tunggal (Single Responsibility Principle). Berikut perbandingannya:
+
+| Aspek                | Conditional (if/else)                          | Strategy Pattern                                                      |
+| -------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
+| **Extensibility**    | Setiap resource type baru = ubah kode yang ada | Tambah kelas baru, tanpa menyentuh kelas lama (Open/Closed Principle) |
+| **Maintainability**  | Logika semua resource tercampur satu file      | Setiap resource punya kelas sendiri, mudah dicari & dipahami          |
+| **Testability**      | Harus mock semua cabang sekaligus              | Setiap strategi di-test secara independen dan terisolasi              |
+| **Controller Layer** | Controller tahu detail setiap resource         | Controller hanya tahu interface, buta terhadap implementasi           |
+
+Spring mendukung Strategy Pattern secara native: semua bean yang mengimplementasikan `IDRDataFetcher` otomatis dikumpulkan ke dalam `Map<String, IDRDataFetcher>` berdasarkan nama bean-nya (`@Component("latest_idr_rates")`). Controller cukup melakukan lookup `map.get(resourceType)` — tidak ada `if/else` atau `switch` sama sekali.
+
+### 2. Client Factory – FactoryBean
+
+**Mengapa FactoryBean, bukan `@Bean` biasa?**
+
+`FactoryBean<WebClient>` dipilih karena memberikan kontrol penuh atas _lifecycle_ dan _konfigurasi_ pembuatan client:
+
+- **Separation of Concerns:** Seluruh logika konfigurasi client (timeout, base URL, header default) terenkapsulasi dalam satu kelas yang didedikasikan, bukan tersebar di `@Configuration`.
+- **Externalizable Config:** `FrankfurterProperties` diinjeksikan ke `FactoryBean`, memastikan Base URL dan timeout selalu dibaca dari `application.yml` — tidak ada nilai hardcoded.
+- **Singleton Guarantee:** `isSingleton() = true` memastikan satu instance `WebClient` dipakai ulang di seluruh aplikasi, efisien secara resource.
+- **Testability:** `WebClientFactoryBean` dapat diinstansiasi dan dikonfigurasi secara independen dalam test tanpa perlu menjalankan Spring context.
+
+Dibanding `@Bean` biasa yang hanya mengembalikan objek langsung, `FactoryBean` memungkinkan logika konstruksi yang lebih kompleks dan dapat dikontrol penuh oleh programmer.
+
+### 3. Startup Runner Choice – ApplicationRunner vs @PostConstruct
+
+**Mengapa ApplicationRunner, bukan `@PostConstruct`?**
+
+| Aspek                 | `@PostConstruct`                                                     | `ApplicationRunner`                                              |
+| --------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Timing**            | Dipanggil selama inisialisasi bean (sebelum context refresh selesai) | Dipanggil setelah context refresh _penuh_ – semua bean siap      |
+| **Dependency Safety** | Berisiko race condition jika ada dependensi yang belum siap          | Semua dependensi pasti sudah terbuat dan terkonfigurasi          |
+| **Error Handling**    | Exception bisa menyebabkan bean gagal dibuat saja                    | Kegagalan langsung menghentikan startup – lebih eksplisit        |
+| **Testability**       | Sulit di-mock dalam `@SpringBootTest`                                | Mudah diverifikasi via integration test dengan `@SpringBootTest` |
+| **Args Access**       | Tidak ada akses ke command-line args                                 | Dapat mengakses `ApplicationArguments` jika diperlukan           |
+
+Dengan `ApplicationRunner`, kita yakin bahwa saat endpoint pertama kali menerima request, `FinanceDataStore` _pasti_ sudah terisi. Kegagalan `run()` yang menyebabkan exception secara eksplisit menghentikan startup, mencegah aplikasi berjalan dalam kondisi data kosong.
+
+---
+
+## 📁 Struktur Proyek
+
+```
+src/main/java/com/allobank/finance/
+├── FinanceApplication.java              # Entry point
+├── config/
+│   ├── FrankfurterProperties.java       # @ConfigurationProperties
+│   ├── WebClientFactoryBean.java        # FactoryBean<WebClient> (Constraint B)
+│   └── AppConfig.java                   # Mendaftarkan FactoryBean
+├── controller/
+│   └── FinanceController.java           # GET /api/finance/data/{resourceType}
+├── exception/
+│   ├── ExternalApiException.java
+│   ├── GlobalExceptionHandler.java
+│   └── ResourceNotFoundException.java
+├── model/
+│   ├── ApiResponse.java
+│   ├── FinanceDataResult.java           # Java Record (immutable)
+│   ├── HistoricalRateResponse.java
+│   └── LatestRateResponse.java
+├── runner/
+│   └── DataIngestionRunner.java         # ApplicationRunner (Constraint C)
+├── service/
+│   └── FinanceDataService.java          # Orchestrator
+├── store/
+│   └── FinanceDataStore.java            # Thread-safe store (Constraint C)
+└── strategy/
+    ├── IDRDataFetcher.java              # Strategy Interface (Constraint A)
+    └── impl/
+        ├── LatestIdrRatesFetcher.java   # + USD_BuySpread_IDR calculation
+        ├── HistoricalIdrUsdFetcher.java
+        └── SupportedCurrenciesFetcher.java
+
+src/test/java/com/allobank/finance/
+├── FinanceApplicationTests.java
+├── runner/
+│   └── DataIngestionRunnerIntegrationTest.java
+└── strategy/
+    ├── LatestIdrRatesFetcherTest.java
+    ├── HistoricalIdrUsdFetcherTest.java
+    └── SupportedCurrenciesFetcherTest.java
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.11</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.allobank</groupId>
+	<artifactId>finance</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>finance</name>
+	<description>Take Home Test</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- OkHttp MockWebServer untuk unit test WebClient -->
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>4.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.12.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/allobank/finance/FinanceApplication.java
+++ b/src/main/java/com/allobank/finance/FinanceApplication.java
@@ -1,0 +1,13 @@
+package com.allobank.finance;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FinanceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(FinanceApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/allobank/finance/config/AppConfig.java
+++ b/src/main/java/com/allobank/finance/config/AppConfig.java
@@ -1,0 +1,41 @@
+package com.allobank.finance.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Konfigurasi Spring yang mendaftarkan {@link WebClientFactoryBean} sebagai
+ * bean.
+ * Spring secara otomatis memanggil {@link WebClientFactoryBean#getObject()}
+ * sehingga bean bertipe WebClient tersedia untuk injection di seluruh aplikasi.
+ */
+@Configuration
+public class AppConfig {
+
+    private final FrankfurterProperties properties;
+
+    public AppConfig(FrankfurterProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Mendaftarkan FactoryBean – Spring akan menggunakannya untuk menghasilkan
+     * instance {@link WebClient}. Sesuai Constraint B: pembuatan client dilakukan
+     * melalui FactoryBean, bukan @Bean langsung yang mengembalikan WebClient.
+     */
+    @Bean
+    public WebClientFactoryBean frankfurterWebClientFactory() {
+        return new WebClientFactoryBean(properties);
+    }
+
+    /**
+     * Bean WebClient yang dihasilkan dari FactoryBean.
+     * Nama bean "frankfurterWebClient" digunakan agar tidak konflik
+     * dengan WebClient bean lain yang mungkin ada.
+     */
+    @Bean(name = "frankfurterWebClient")
+    public WebClient frankfurterWebClient(WebClientFactoryBean factory) throws Exception {
+        return factory.getObject();
+    }
+}

--- a/src/main/java/com/allobank/finance/config/FrankfurterProperties.java
+++ b/src/main/java/com/allobank/finance/config/FrankfurterProperties.java
@@ -1,0 +1,22 @@
+package com.allobank.finance.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+// Todo : frankfurter properties
+@Data
+@Component
+@ConfigurationProperties(prefix = "frankfurter")
+public class FrankfurterProperties {
+
+    private String baseUrl;
+
+    private String githubUsername;
+
+    private String historicalStart;
+
+    private String historicalEnd;
+
+    private int timeoutSeconds = 10;
+}

--- a/src/main/java/com/allobank/finance/config/WebClientFactoryBean.java
+++ b/src/main/java/com/allobank/finance/config/WebClientFactoryBean.java
@@ -1,0 +1,72 @@
+package com.allobank.finance.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.Setter;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * FactoryBean khusus untuk membuat instance WebClient yang terkoneksi ke
+ * Frankfurter API.
+ *
+ * <p>
+ * Mengimplementasikan {@link FactoryBean} sesuai Constraint B:
+ * - Eksternalisasi Base URL via {@link FrankfurterProperties}
+ * - Konfigurasi timeout (connect + read + write)
+ * - Menetapkan default header Accept: application/json
+ *
+ * <p>
+ * Tidak menggunakan @Bean langsung di @Configuration melainkan FactoryBean
+ * agar konfigurasi client lebih terpusat, testable, dan memisahkan tanggung
+ * jawab
+ * pembuatan client dari konfigurasi aplikasi umum.
+ */
+@Setter
+public class WebClientFactoryBean implements FactoryBean<WebClient> {
+
+    private final FrankfurterProperties properties;
+
+    public WebClientFactoryBean(FrankfurterProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public WebClient getObject() {
+        int timeoutSeconds = properties.getTimeoutSeconds();
+
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) Duration.ofSeconds(timeoutSeconds).toMillis())
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(timeoutSeconds, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(timeoutSeconds, TimeUnit.SECONDS)));
+
+        return WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+    /**
+     * Singleton: satu instance WebClient dipakai ulang di seluruh aplikasi.
+     */
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/allobank/finance/controller/FinanceController.java
+++ b/src/main/java/com/allobank/finance/controller/FinanceController.java
@@ -1,0 +1,36 @@
+package com.allobank.finance.controller;
+
+import com.allobank.finance.model.ApiResponse;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.service.FinanceDataService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/finance")
+public class FinanceController {
+
+    private final FinanceDataService financeDataService;
+
+    public FinanceController(FinanceDataService financeDataService) {
+        this.financeDataService = financeDataService;
+    }
+
+    @GetMapping("/data/{resourceType}")
+    public ResponseEntity<ApiResponse<List<FinanceDataResult>>> getFinanceData(
+            @PathVariable String resourceType) {
+
+        log.info("Request diterima: GET /api/finance/data/{}", resourceType);
+
+        List<FinanceDataResult> data = financeDataService.getData(resourceType);
+
+        return ResponseEntity.ok(ApiResponse.success(data));
+    }
+}

--- a/src/main/java/com/allobank/finance/exception/ExternalApiException.java
+++ b/src/main/java/com/allobank/finance/exception/ExternalApiException.java
@@ -1,0 +1,16 @@
+package com.allobank.finance.exception;
+
+/**
+ * Exception yang dilempar ketika terjadi kegagalan saat mengambil data
+ * dari Frankfurter API (network error, 4xx, 5xx).
+ */
+public class ExternalApiException extends RuntimeException {
+
+    public ExternalApiException(String message) {
+        super(message);
+    }
+
+    public ExternalApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/allobank/finance/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/allobank/finance/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.allobank.finance.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+// Todo : global exception handler
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+        @ExceptionHandler(ResourceNotFoundException.class)
+        public ResponseEntity<Map<String, Object>> handleResourceNotFound(ResourceNotFoundException ex) {
+                log.warn("Resource tidak ditemukan: {}", ex.getMessage());
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                .body(Map.of(
+                                                "status", "error",
+                                                "httpCode", 404,
+                                                "message", ex.getMessage()));
+        }
+
+        @ExceptionHandler(ExternalApiException.class)
+        public ResponseEntity<Map<String, Object>> handleExternalApiError(ExternalApiException ex) {
+                log.error("Kesalahan komunikasi dengan API eksternal: {}", ex.getMessage(), ex);
+                return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                                .body(Map.of(
+                                                "status", "error",
+                                                "httpCode", 503,
+                                                "message", "Layanan eksternal tidak tersedia: " + ex.getMessage()));
+        }
+
+        @ExceptionHandler(Exception.class)
+        public ResponseEntity<Map<String, Object>> handleGenericError(Exception ex) {
+                log.error("Kesalahan tidak tertangani: {}", ex.getMessage(), ex);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .body(Map.of(
+                                                "status", "error",
+                                                "httpCode", 500,
+                                                "message", "Terjadi kesalahan internal server"));
+        }
+}

--- a/src/main/java/com/allobank/finance/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/allobank/finance/exception/ResourceNotFoundException.java
@@ -1,0 +1,13 @@
+package com.allobank.finance.exception;
+
+/**
+ * Exception yang dilempar ketika resourceType yang diminta tidak ditemukan
+ * di in-memory store (misalnya resource type tidak dikenal).
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String resourceType) {
+        super("Resource type tidak ditemukan: '" + resourceType + "'. " +
+                "Nilai yang valid: latest_idr_rates, historical_idr_usd, supported_currencies");
+    }
+}

--- a/src/main/java/com/allobank/finance/model/ApiResponse.java
+++ b/src/main/java/com/allobank/finance/model/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.allobank.finance.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// Todo : api response
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private String status;
+
+    private String message;
+
+    private T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", "Data berhasil diambil", data);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>("error", message, null);
+    }
+}

--- a/src/main/java/com/allobank/finance/model/FinanceDataResult.java
+++ b/src/main/java/com/allobank/finance/model/FinanceDataResult.java
@@ -1,0 +1,5 @@
+package com.allobank.finance.model;
+
+// Todo : finance data result untuk menyatukan semua tipe resource dalam satu format yang seragam
+public record FinanceDataResult(String resourceType, Object data) {
+}

--- a/src/main/java/com/allobank/finance/model/HistoricalRateResponse.java
+++ b/src/main/java/com/allobank/finance/model/HistoricalRateResponse.java
@@ -1,0 +1,31 @@
+package com.allobank.finance.model;
+
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * DTO untuk respons dari endpoint Frankfurter historical (date range).
+ * Contoh: /2024-01-01..2024-01-05?from=IDR&to=USD
+ */
+@Data
+public class HistoricalRateResponse {
+
+    /** Jumlah base currency */
+    private double amount;
+
+    /** Kode mata uang dasar (IDR) */
+    private String base;
+
+    /** Tanggal mulai range */
+    private String startDate;
+
+    /** Tanggal akhir range */
+    private String endDate;
+
+    /**
+     * Map tanggal → (Map simbol → nilai tukar).
+     * Contoh: {"2024-01-02": {"USD": 0.000064}}
+     */
+    private Map<String, Map<String, Double>> rates;
+}

--- a/src/main/java/com/allobank/finance/model/LatestRateResponse.java
+++ b/src/main/java/com/allobank/finance/model/LatestRateResponse.java
@@ -1,0 +1,35 @@
+package com.allobank.finance.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * DTO untuk respons dari endpoint Frankfurter /latest?base=IDR.
+ * Digunakan oleh
+ * {@link com.allobank.finance.strategy.impl.LatestIdrRatesFetcher}.
+ */
+@Data
+public class LatestRateResponse {
+
+    /** Jumlah base currency (selalu 1.0 untuk IDR) */
+    private double amount;
+
+    /** Kode mata uang dasar (IDR) */
+    private String base;
+
+    /** Tanggal rate berlaku */
+    private String date;
+
+    /** Map simbol mata uang → nilai tukar terhadap IDR */
+    private Map<String, Double> rates;
+
+    /**
+     * Field tambahan hasil kalkulasi business logic:
+     * Harga jual USD dalam IDR setelah spread perbankan.
+     * Tidak berasal dari API, dihitung di aplikasi.
+     */
+    @JsonProperty("USD_BuySpread_IDR")
+    private Double usdBuySpreadIdr;
+}

--- a/src/main/java/com/allobank/finance/runner/DataIngestionRunner.java
+++ b/src/main/java/com/allobank/finance/runner/DataIngestionRunner.java
@@ -1,0 +1,61 @@
+package com.allobank.finance.runner;
+
+import com.allobank.finance.service.FinanceDataService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Startup runner yang memuat semua data dari Frankfurter API tepat satu kali
+ * saat aplikasi pertama kali dimulai, sebelum menerima request HTTP.
+ *
+ * <p>
+ * <b>Mengapa ApplicationRunner (Constraint C)?</b>
+ * <ul>
+ * <li>ApplicationRunner dieksekusi setelah Spring context sepenuhnya
+ * ter-refresh
+ * dan semua bean siap digunakan, memastikan dependensi seperti WebClient
+ * sudah tersedia dan sudah dikonfigurasi.</li>
+ * <li>Berbeda dengan {@code @PostConstruct} yang dipanggil selama fase
+ * inisialisasi bean
+ * (sebelum context refresh selesai penuh), ApplicationRunner menjamin urutan
+ * eksekusi
+ * yang tepat dan lebih mudah di-test secara integrasi.</li>
+ * <li>Spring Boot menjamin ApplicationRunner selesai sebelum aplikasi mulai
+ * menerima
+ * traffic produksi, sehingga endpoint tidak pernah melayani data kosong.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class DataIngestionRunner implements ApplicationRunner {
+
+    private final FinanceDataService financeDataService;
+    private final WebClient webClient;
+
+    public DataIngestionRunner(FinanceDataService financeDataService,
+            @Qualifier("frankfurterWebClient") WebClient webClient) {
+        this.financeDataService = financeDataService;
+        this.webClient = webClient;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("=== DataIngestionRunner: Memulai inisialisasi data dari Frankfurter API ===");
+        long startTime = System.currentTimeMillis();
+
+        try {
+            financeDataService.loadAll(webClient);
+            long elapsed = System.currentTimeMillis() - startTime;
+            log.info("=== DataIngestionRunner: Data berhasil dimuat dalam {} ms ===", elapsed);
+        } catch (Exception e) {
+            log.error("=== DataIngestionRunner: GAGAL memuat data! Aplikasi mungkin tidak berfungsi dengan benar. " +
+                    "Error: {} ===", e.getMessage(), e);
+            // Kita lempar ulang agar aplikasi gagal startup jika data tidak bisa dimuat
+            throw new RuntimeException("Gagal memuat data awal dari Frankfurter API", e);
+        }
+    }
+}

--- a/src/main/java/com/allobank/finance/service/FinanceDataService.java
+++ b/src/main/java/com/allobank/finance/service/FinanceDataService.java
@@ -1,0 +1,76 @@
+package com.allobank.finance.service;
+
+import com.allobank.finance.exception.ResourceNotFoundException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.store.FinanceDataStore;
+import com.allobank.finance.strategy.IDRDataFetcher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service layer yang mengorkestrasikan pengambilan data menggunakan strategi
+ * dan menyajikannya dari in-memory store.
+ */
+@Slf4j
+@Service
+public class FinanceDataService {
+
+    private final FinanceDataStore dataStore;
+    private final Map<String, IDRDataFetcher> fetcherMap;
+
+    /**
+     * Spring secara otomatis menginjeksikan semua bean yang mengimplementasikan
+     * {@link IDRDataFetcher} ke dalam Map dengan key = nama bean (@Component
+     * value).
+     * Ini adalah cara Spring mendukung map-based strategy lookup.
+     */
+    public FinanceDataService(FinanceDataStore dataStore,
+            Map<String, IDRDataFetcher> fetcherMap) {
+        this.dataStore = dataStore;
+        this.fetcherMap = fetcherMap;
+        log.info("FinanceDataService diinisialisasi dengan {} strategi: {}",
+                fetcherMap.size(), fetcherMap.keySet());
+    }
+
+    /**
+     * Memuat semua data dari Frankfurter API menggunakan setiap strategi yang
+     * tersedia.
+     * Dipanggil sekali saat startup oleh
+     * {@link com.allobank.finance.runner.DataIngestionRunner}.
+     *
+     * @param webClient WebClient yang sudah dikonfigurasi
+     */
+    public void loadAll(WebClient webClient) {
+        log.info("Mulai memuat data untuk semua {} resource types...", fetcherMap.size());
+
+        Map<String, List<FinanceDataResult>> allData = new HashMap<>();
+
+        fetcherMap.forEach((resourceType, fetcher) -> {
+            log.info("Mengambil data untuk resource type: '{}'", resourceType);
+            List<FinanceDataResult> results = fetcher.fetch(webClient);
+            allData.put(resourceType, results);
+            log.info("Berhasil memuat data untuk '{}': {} item", resourceType, results.size());
+        });
+
+        dataStore.initialize(allData);
+        log.info("Semua data berhasil dimuat ke FinanceDataStore.");
+    }
+
+    /**
+     * Mengambil data dari in-memory store berdasarkan resource type.
+     * Controller memanggil method ini — tidak ada akses langsung ke eksternal API.
+     *
+     * @param resourceType jenis resource yang diminta
+     * @return daftar hasil data
+     * @throws ResourceNotFoundException jika resource type tidak dikenal
+     */
+    public List<FinanceDataResult> getData(String resourceType) {
+        return dataStore.getByResourceType(resourceType)
+                .orElseThrow(() -> new ResourceNotFoundException(resourceType));
+    }
+}

--- a/src/main/java/com/allobank/finance/store/FinanceDataStore.java
+++ b/src/main/java/com/allobank/finance/store/FinanceDataStore.java
@@ -1,0 +1,51 @@
+package com.allobank.finance.store;
+
+import com.allobank.finance.model.FinanceDataResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+// Todo : finance data store
+@Slf4j
+@Component
+public class FinanceDataStore {
+
+    private final AtomicReference<Map<String, List<FinanceDataResult>>> storeRef = new AtomicReference<>(
+            Collections.emptyMap());
+
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    public void initialize(Map<String, List<FinanceDataResult>> data) {
+        if (!initialized.compareAndSet(false, true)) {
+            throw new IllegalStateException(
+                    "FinanceDataStore sudah diinisialisasi. initialize() hanya boleh dipanggil sekali.");
+        }
+
+        Map<String, List<FinanceDataResult>> immutableData = data.entrySet().stream()
+                .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        entry -> Collections.unmodifiableList(entry.getValue())));
+
+        storeRef.set(Collections.unmodifiableMap(immutableData));
+        log.info("FinanceDataStore berhasil diinisialisasi dengan {} resource types: {}",
+                immutableData.size(), immutableData.keySet());
+    }
+
+    public Optional<List<FinanceDataResult>> getByResourceType(String resourceType) {
+        return Optional.ofNullable(storeRef.get().get(resourceType));
+    }
+
+    public boolean isInitialized() {
+        return initialized.get();
+    }
+
+    public Map<String, List<FinanceDataResult>> getAll() {
+        return storeRef.get();
+    }
+}

--- a/src/main/java/com/allobank/finance/strategy/IDRDataFetcher.java
+++ b/src/main/java/com/allobank/finance/strategy/IDRDataFetcher.java
@@ -1,0 +1,16 @@
+package com.allobank.finance.strategy;
+
+import com.allobank.finance.model.FinanceDataResult;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+// Todo : idr data fetcher
+public interface IDRDataFetcher {
+
+    // Todo : get resource type
+    String getResourceType();
+
+    // Todo : fetch data from Frankfurter API
+    List<FinanceDataResult> fetch(WebClient webClient);
+}

--- a/src/main/java/com/allobank/finance/strategy/impl/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/com/allobank/finance/strategy/impl/HistoricalIdrUsdFetcher.java
@@ -1,0 +1,77 @@
+package com.allobank.finance.strategy.impl;
+
+import com.allobank.finance.config.FrankfurterProperties;
+import com.allobank.finance.exception.ExternalApiException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.model.HistoricalRateResponse;
+import com.allobank.finance.strategy.IDRDataFetcher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+/**
+ * Strategi untuk mengambil data historis kurs IDR→USD
+ * pada rentang tanggal yang dikonfigurasi di application.yml.
+ *
+ * <p>
+ * Endpoint yang dipanggil: /{start}..{end}?from=IDR&to=USD
+ */
+@Slf4j
+@Component("historical_idr_usd")
+public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "historical_idr_usd";
+
+    private final FrankfurterProperties properties;
+
+    public HistoricalIdrUsdFetcher(FrankfurterProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String getResourceType() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
+    public List<FinanceDataResult> fetch(WebClient webClient) {
+        String startDate = properties.getHistoricalStart();
+        String endDate = properties.getHistoricalEnd();
+        String uri = "/" + startDate + ".." + endDate + "?from=IDR&to=USD";
+
+        log.info("Mengambil data historis IDR→USD dari Frankfurter API: {}", uri);
+
+        try {
+            HistoricalRateResponse response = webClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .map(body -> new ExternalApiException(
+                                            "Frankfurter API error " + clientResponse.statusCode() + ": " + body)))
+                    .bodyToMono(HistoricalRateResponse.class)
+                    .block();
+
+            if (response == null) {
+                throw new ExternalApiException("Response kosong dari Frankfurter API " + uri);
+            }
+
+            log.info("Data historis IDR→USD berhasil diambil: {} entri tanggal",
+                    response.getRates() != null ? response.getRates().size() : 0);
+
+            return List.of(new FinanceDataResult(RESOURCE_TYPE, response));
+
+        } catch (WebClientResponseException e) {
+            throw new ExternalApiException(
+                    "Gagal mengambil data historis IDR→USD: " + e.getMessage(), e);
+        } catch (ExternalApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ExternalApiException(
+                    "Kesalahan tidak terduga saat mengambil data historis: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/allobank/finance/strategy/impl/LatestIdrRatesFetcher.java
+++ b/src/main/java/com/allobank/finance/strategy/impl/LatestIdrRatesFetcher.java
@@ -1,0 +1,112 @@
+package com.allobank.finance.strategy.impl;
+
+import com.allobank.finance.config.FrankfurterProperties;
+import com.allobank.finance.exception.ExternalApiException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.model.LatestRateResponse;
+import com.allobank.finance.strategy.IDRDataFetcher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strategi untuk mengambil kurs IDR terbaru dari Frankfurter API
+ * dan menghitung field tambahan USD_BuySpread_IDR.
+ *
+ * <p>
+ * <b>Kalkulasi Spread Factor:</b>
+ *
+ * <pre>
+ *   GitHub Username  : ramandry12
+ *   Unicode Sum      : r(114)+a(97)+m(109)+a(97)+n(110)+d(100)+r(114)+y(121)+1(49)+2(50) = 961
+ *   Spread Factor    : (961 % 1000) / 100000.0 = 961 / 100000.0 = 0.00961
+ *   USD_BuySpread_IDR = (1 / Rate_USD) * (1 + 0.00961)
+ * </pre>
+ */
+@Slf4j
+@Component("latest_idr_rates")
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "latest_idr_rates";
+
+    private final double spreadFactor;
+
+    public LatestIdrRatesFetcher(FrankfurterProperties properties) {
+        this.spreadFactor = calculateSpreadFactor(properties.getGithubUsername());
+        log.info("LatestIdrRatesFetcher diinisialisasi dengan spreadFactor={} (dari username='{}')",
+                spreadFactor, properties.getGithubUsername());
+    }
+
+    @Override
+    public String getResourceType() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
+    public List<FinanceDataResult> fetch(WebClient webClient) {
+        log.info("Mengambil latest IDR rates dari Frankfurter API...");
+        try {
+            LatestRateResponse response = webClient.get()
+                    .uri("/latest?base=IDR")
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .map(body -> new ExternalApiException(
+                                            "Frankfurter API error " + clientResponse.statusCode() + ": " + body)))
+                    .bodyToMono(LatestRateResponse.class)
+                    .block();
+
+            if (response == null) {
+                throw new ExternalApiException("Response kosong dari Frankfurter API /latest");
+            }
+
+            // Hitung USD_BuySpread_IDR
+            Map<String, Double> rates = response.getRates();
+            if (rates != null && rates.containsKey("USD")) {
+                double rateUsd = rates.get("USD");
+                double usdBuySpreadIdr = (1.0 / rateUsd) * (1.0 + spreadFactor);
+                response.setUsdBuySpreadIdr(usdBuySpreadIdr);
+                log.info("USD BuySpread IDR dihitung: rate_USD={}, spreadFactor={}, result={}",
+                        rateUsd, spreadFactor, usdBuySpreadIdr);
+            } else {
+                log.warn("Rate USD tidak ditemukan dalam respons API");
+            }
+
+            return List.of(new FinanceDataResult(RESOURCE_TYPE, response));
+
+        } catch (WebClientResponseException e) {
+            throw new ExternalApiException(
+                    "Gagal mengambil latest IDR rates: " + e.getMessage(), e);
+        } catch (ExternalApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ExternalApiException(
+                    "Kesalahan tidak terduga saat mengambil latest IDR rates: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Menghitung spread factor berdasarkan GitHub username.
+     *
+     * <p>
+     * Formula:
+     * <ol>
+     * <li>Hitung jumlah nilai Unicode dari semua karakter username (lowercase)</li>
+     * <li>Spread Factor = (sum % 1000) / 100000.0</li>
+     * </ol>
+     *
+     * @param githubUsername username GitHub
+     * @return spread factor dalam rentang [0.00000, 0.00999]
+     */
+    public static double calculateSpreadFactor(String githubUsername) {
+        if (githubUsername == null || githubUsername.isBlank()) {
+            throw new IllegalArgumentException("GitHub username tidak boleh kosong");
+        }
+        int unicodeSum = githubUsername.toLowerCase().chars().sum();
+        return (unicodeSum % 1000) / 100000.0;
+    }
+}

--- a/src/main/java/com/allobank/finance/strategy/impl/SupportedCurrenciesFetcher.java
+++ b/src/main/java/com/allobank/finance/strategy/impl/SupportedCurrenciesFetcher.java
@@ -1,0 +1,61 @@
+package com.allobank.finance.strategy.impl;
+
+import com.allobank.finance.exception.ExternalApiException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.strategy.IDRDataFetcher;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+import java.util.Map;
+
+// Todo : supported currencies fetcher
+@Slf4j
+@Component("supported_currencies")
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "supported_currencies";
+
+    @Override
+    public String getResourceType() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
+    public List<FinanceDataResult> fetch(WebClient webClient) {
+        log.info("Mengambil daftar mata uang yang didukung dari Frankfurter API...");
+
+        try {
+            Map<String, String> currencies = webClient.get()
+                    .uri("/currencies")
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                            clientResponse -> clientResponse.bodyToMono(String.class)
+                                    .map(body -> new ExternalApiException(
+                                            "Frankfurter API error " + clientResponse.statusCode() + ": " + body)))
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {
+                    })
+                    .block();
+
+            if (currencies == null) {
+                throw new ExternalApiException("Response kosong dari Frankfurter API /currencies");
+            }
+
+            log.info("Berhasil mengambil {} mata uang yang didukung", currencies.size());
+
+            return List.of(new FinanceDataResult(RESOURCE_TYPE, currencies));
+
+        } catch (WebClientResponseException e) {
+            throw new ExternalApiException(
+                    "Gagal mengambil daftar mata uang: " + e.getMessage(), e);
+        } catch (ExternalApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ExternalApiException(
+                    "Kesalahan tidak terduga saat mengambil daftar mata uang: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <!-- ══════════════════════════════════════════════
+         PROPERTI GLOBAL
+    ══════════════════════════════════════════════ -->
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="finance"/>
+    <springProperty scope="context" name="LOG_DIR"  source="logging.file.path"       defaultValue="logs"/>
+
+    <property name="LOG_PATTERN_CONSOLE" value="%d{HH:mm:ss.SSS} %-5level %logger{30} - %msg%n"/>
+    <property name="LOG_PATTERN_FILE"    value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n"/>
+
+    <!-- ══════════════════════════════════════════════
+         APPENDER: CONSOLE — minimal, hanya startup + WARN/ERROR
+    ══════════════════════════════════════════════ -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN_CONSOLE}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <!-- Hanya WARN ke atas yang lolos ke konsol -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <!-- CONSOLE khusus pasang-startup — INFO diizinkan untuk logger startup Spring -->
+    <appender name="CONSOLE_STARTUP" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN_CONSOLE}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- ══════════════════════════════════════════════
+         APPENDER: FILE UTAMA (finance.log) — semua INFO
+    ══════════════════════════════════════════════ -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${APP_NAME}.log</file>
+        <encoder>
+            <pattern>${LOG_PATTERN_FILE}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/archived/${APP_NAME}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+    </appender>
+
+    <!-- ══════════════════════════════════════════════
+         APPENDER: FILE ERROR (finance-error.log) — WARN/ERROR saja
+    ══════════════════════════════════════════════ -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${APP_NAME}-error.log</file>
+        <encoder>
+            <pattern>${LOG_PATTERN_FILE}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/archived/${APP_NAME}-error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>200MB</totalSizeCap>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <!-- ASYNC wrappers -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <appender name="ASYNC_ERROR_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>256</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="ERROR_FILE"/>
+    </appender>
+
+    <!-- ══════════════════════════════════════════════
+         LOGGER: Kode aplikasi kita
+         → INFO masuk ke FILE saja (tidak ke konsol)
+    ══════════════════════════════════════════════ -->
+    <logger name="com.allobank.finance" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC_FILE"/>
+        <appender-ref ref="ASYNC_ERROR_FILE"/>
+    </logger>
+
+    <!-- ══════════════════════════════════════════════
+         LOGGER: Spring Boot startup messages
+         → tampil di konsol (Starting, Started, port, dll)
+    ══════════════════════════════════════════════ -->
+    <logger name="org.springframework.boot.StartupInfoLogger" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE_STARTUP"/>
+        <appender-ref ref="ASYNC_FILE"/>
+    </logger>
+
+    <logger name="org.springframework.boot.web.embedded.tomcat" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE_STARTUP"/>
+        <appender-ref ref="ASYNC_FILE"/>
+    </logger>
+
+    <!-- ══════════════════════════════════════════════
+         LOGGER: Library lain → WARN saja
+    ══════════════════════════════════════════════ -->
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="reactor.netty"       level="WARN"/>
+    <logger name="io.netty"            level="WARN"/>
+    <logger name="okhttp3"             level="WARN"/>
+
+    <!-- ══════════════════════════════════════════════
+         ROOT — fallback: WARN ke konsol + file
+    ══════════════════════════════════════════════ -->
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ASYNC_FILE"/>
+        <appender-ref ref="ASYNC_ERROR_FILE"/>
+    </root>
+
+</configuration>

--- a/src/test/java/com/allobank/finance/FinanceApplicationTests.java
+++ b/src/test/java/com/allobank/finance/FinanceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.allobank.finance;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FinanceApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/allobank/finance/runner/DataIngestionRunnerIntegrationTest.java
+++ b/src/test/java/com/allobank/finance/runner/DataIngestionRunnerIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.allobank.finance.runner;
+
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.store.FinanceDataStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test untuk memverifikasi bahwa {@link DataIngestionRunner}
+ * berhasil memuat semua data ke {@link FinanceDataStore} saat aplikasi startup.
+ *
+ * <p>
+ * Test ini menggunakan Spring context nyata dengan profil "test"
+ * yang terhubung ke Frankfurter API yang sesungguhnya.
+ * Jika koneksi internet tidak tersedia, test ini akan dilewati.
+ *
+ * <p>
+ * Sesuai ketentuan: memverifikasi bahwa setelah ApplicationRunner selesai,
+ * store berisi data yang tidak kosong untuk ketiga resource type.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class DataIngestionRunnerIntegrationTest {
+
+    @Autowired
+    private FinanceDataStore financeDataStore;
+
+    @Test
+    @DisplayName("Store harus diinisialisasi setelah aplikasi startup")
+    void storeShouldBeInitializedAfterStartup() {
+        assertThat(financeDataStore.isInitialized())
+                .as("FinanceDataStore harus sudah diinisialisasi oleh ApplicationRunner")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Store harus berisi data untuk 'latest_idr_rates'")
+    void storeShouldContainLatestIdrRates() {
+        Optional<List<FinanceDataResult>> data = financeDataStore.getByResourceType("latest_idr_rates");
+
+        assertThat(data)
+                .as("latest_idr_rates harus ada di store")
+                .isPresent();
+        assertThat(data.get())
+                .as("latest_idr_rates tidak boleh kosong")
+                .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Store harus berisi data untuk 'historical_idr_usd'")
+    void storeShouldContainHistoricalIdrUsd() {
+        Optional<List<FinanceDataResult>> data = financeDataStore.getByResourceType("historical_idr_usd");
+
+        assertThat(data)
+                .as("historical_idr_usd harus ada di store")
+                .isPresent();
+        assertThat(data.get())
+                .as("historical_idr_usd tidak boleh kosong")
+                .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Store harus berisi data untuk 'supported_currencies'")
+    void storeShouldContainSupportedCurrencies() {
+        Optional<List<FinanceDataResult>> data = financeDataStore.getByResourceType("supported_currencies");
+
+        assertThat(data)
+                .as("supported_currencies harus ada di store")
+                .isPresent();
+        assertThat(data.get())
+                .as("supported_currencies tidak boleh kosong")
+                .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Store harus berisi tepat 3 resource types")
+    void storeShouldContainExactlyThreeResourceTypes() {
+        assertThat(financeDataStore.getAll())
+                .as("Harus ada tepat 3 resource type yang dimuat")
+                .hasSize(3)
+                .containsKeys("latest_idr_rates", "historical_idr_usd", "supported_currencies");
+    }
+}

--- a/src/test/java/com/allobank/finance/strategy/HistoricalIdrUsdFetcherTest.java
+++ b/src/test/java/com/allobank/finance/strategy/HistoricalIdrUsdFetcherTest.java
@@ -1,0 +1,109 @@
+package com.allobank.finance.strategy;
+
+import com.allobank.finance.config.FrankfurterProperties;
+import com.allobank.finance.exception.ExternalApiException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.model.HistoricalRateResponse;
+import com.allobank.finance.strategy.impl.HistoricalIdrUsdFetcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit test untuk {@link HistoricalIdrUsdFetcher}.
+ */
+class HistoricalIdrUsdFetcherTest {
+
+    private MockWebServer mockWebServer;
+    private WebClient webClient;
+    private HistoricalIdrUsdFetcher fetcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        FrankfurterProperties properties = new FrankfurterProperties();
+        properties.setHistoricalStart("2024-01-01");
+        properties.setHistoricalEnd("2024-01-05");
+        fetcher = new HistoricalIdrUsdFetcher(properties);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Harus mengembalikan resource type yang benar")
+    void shouldReturnCorrectResourceType() {
+        assertThat(fetcher.getResourceType()).isEqualTo("historical_idr_usd");
+    }
+
+    @Test
+    @DisplayName("Harus mengembalikan data historis IDR→USD dengan benar")
+    void shouldFetchHistoricalDataSuccessfully() {
+        // Given: mock response historical rates
+        String mockBody = """
+                {
+                    "amount": 1.0,
+                    "base": "IDR",
+                    "start_date": "2024-01-01",
+                    "end_date": "2024-01-05",
+                    "rates": {
+                        "2024-01-02": {"USD": 0.000064},
+                        "2024-01-03": {"USD": 0.000064},
+                        "2024-01-04": {"USD": 0.000065},
+                        "2024-01-05": {"USD": 0.000064}
+                    }
+                }
+                """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockBody)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        // When
+        List<FinanceDataResult> results = fetcher.fetch(webClient);
+
+        // Then
+        assertThat(results).hasSize(1);
+
+        FinanceDataResult result = results.get(0);
+        assertThat(result.resourceType()).isEqualTo("historical_idr_usd");
+
+        HistoricalRateResponse response = (HistoricalRateResponse) result.data();
+        assertThat(response).isNotNull();
+        assertThat(response.getBase()).isEqualTo("IDR");
+        assertThat(response.getRates()).hasSize(4);
+        assertThat(response.getRates()).containsKey("2024-01-02");
+        assertThat(response.getRates().get("2024-01-02")).containsEntry("USD", 0.000064);
+    }
+
+    @Test
+    @DisplayName("Harus melempar ExternalApiException ketika API gagal (5xx)")
+    void shouldThrowExternalApiExceptionOnServerError() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal Server Error"));
+
+        assertThatThrownBy(() -> fetcher.fetch(webClient))
+                .isInstanceOf(ExternalApiException.class);
+    }
+}

--- a/src/test/java/com/allobank/finance/strategy/LatestIdrRatesFetcherTest.java
+++ b/src/test/java/com/allobank/finance/strategy/LatestIdrRatesFetcherTest.java
@@ -1,0 +1,143 @@
+package com.allobank.finance.strategy;
+
+import com.allobank.finance.config.FrankfurterProperties;
+import com.allobank.finance.exception.ExternalApiException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.model.LatestRateResponse;
+import com.allobank.finance.strategy.impl.LatestIdrRatesFetcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Unit test untuk {@link LatestIdrRatesFetcher}.
+ * Menggunakan MockWebServer untuk menstub HTTP call ke Frankfurter API.
+ */
+class LatestIdrRatesFetcherTest {
+
+    private MockWebServer mockWebServer;
+    private WebClient webClient;
+    private LatestIdrRatesFetcher fetcher;
+
+    // GitHub username: ramandry12
+    // Unicode sum: r=114,a=97,m=109,a=97,n=110,d=100,r=114,y=121,1=49,2=50
+    // Sum = 114+97+109+97+110+100+114+121+49+50 = 961
+    // Spread Factor = (961 % 1000) / 100000.0 = 961 / 100000.0 = 0.00961
+    private static final double EXPECTED_SPREAD_FACTOR = 0.00961;
+    private static final String GITHUB_USERNAME = "ramandry12";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        FrankfurterProperties properties = new FrankfurterProperties();
+        properties.setGithubUsername(GITHUB_USERNAME);
+        fetcher = new LatestIdrRatesFetcher(properties);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Harus mengembalikan resource type yang benar")
+    void shouldReturnCorrectResourceType() {
+        assertThat(fetcher.getResourceType()).isEqualTo("latest_idr_rates");
+    }
+
+    @Test
+    @DisplayName("Harus menghitung spread factor dengan benar untuk username 'ramandry12'")
+    void shouldCalculateSpreadFactorCorrectly() {
+        double actual = LatestIdrRatesFetcher.calculateSpreadFactor(GITHUB_USERNAME);
+        assertThat(actual).isEqualTo(EXPECTED_SPREAD_FACTOR, within(0.000001));
+    }
+
+    @Test
+    @DisplayName("Harus menghitung USD_BuySpread_IDR dengan benar")
+    void shouldCalculateUsdBuySpreadIdr() {
+        // Given: respons mock dari API
+        // Rate USD = 0.000064 (artinya 1 IDR = 0.000064 USD)
+        // 1/0.000064 = 15625.0
+        // 15625.0 * (1 + 0.00961) = 15625.0 * 1.00961 = 15775.15625
+        String mockBody = """
+                {
+                    "amount": 1.0,
+                    "base": "IDR",
+                    "date": "2024-01-05",
+                    "rates": {
+                        "USD": 0.000064,
+                        "EUR": 0.000059
+                    }
+                }
+                """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockBody)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        // When
+        List<FinanceDataResult> results = fetcher.fetch(webClient);
+
+        // Then
+        assertThat(results).hasSize(1);
+        FinanceDataResult result = results.get(0);
+        assertThat(result.resourceType()).isEqualTo("latest_idr_rates");
+
+        LatestRateResponse response = (LatestRateResponse) result.data();
+        assertThat(response).isNotNull();
+        assertThat(response.getBase()).isEqualTo("IDR");
+        assertThat(response.getRates()).containsKey("USD");
+
+        // Verifikasi kalkulasi: (1 / 0.000064) * (1 + 0.00576) = 15715.0
+        double expectedUsdBuySpreadIdr = (1.0 / 0.000064) * (1.0 + EXPECTED_SPREAD_FACTOR);
+        assertThat(response.getUsdBuySpreadIdr())
+                .isEqualTo(expectedUsdBuySpreadIdr, within(0.01));
+    }
+
+    @Test
+    @DisplayName("Harus melempar ExternalApiException ketika API mengembalikan 500")
+    void shouldThrowExternalApiExceptionOnServerError() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500).setBody("Internal Server Error"));
+
+        assertThatThrownBy(() -> fetcher.fetch(webClient))
+                .isInstanceOf(ExternalApiException.class);
+    }
+
+    @Test
+    @DisplayName("Harus melempar ExternalApiException ketika API mengembalikan 404")
+    void shouldThrowExternalApiExceptionOnClientError() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(404).setBody("Not Found"));
+
+        assertThatThrownBy(() -> fetcher.fetch(webClient))
+                .isInstanceOf(ExternalApiException.class);
+    }
+
+    @Test
+    @DisplayName("calculateSpreadFactor harus melempar exception untuk username kosong")
+    void shouldThrowForBlankUsername() {
+        assertThatThrownBy(() -> LatestIdrRatesFetcher.calculateSpreadFactor(""))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> LatestIdrRatesFetcher.calculateSpreadFactor(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/allobank/finance/strategy/SupportedCurrenciesFetcherTest.java
+++ b/src/test/java/com/allobank/finance/strategy/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,99 @@
+package com.allobank.finance.strategy;
+
+import com.allobank.finance.exception.ExternalApiException;
+import com.allobank.finance.model.FinanceDataResult;
+import com.allobank.finance.strategy.impl.SupportedCurrenciesFetcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit test untuk {@link SupportedCurrenciesFetcher}.
+ */
+class SupportedCurrenciesFetcherTest {
+
+    private MockWebServer mockWebServer;
+    private WebClient webClient;
+    private SupportedCurrenciesFetcher fetcher;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        fetcher = new SupportedCurrenciesFetcher();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Harus mengembalikan resource type yang benar")
+    void shouldReturnCorrectResourceType() {
+        assertThat(fetcher.getResourceType()).isEqualTo("supported_currencies");
+    }
+
+    @Test
+    @DisplayName("Harus mengembalikan daftar mata uang yang benar")
+    void shouldFetchSupportedCurrenciesSuccessfully() {
+        // Given
+        String mockBody = """
+                {
+                    "AUD": "Australian Dollar",
+                    "EUR": "Euro",
+                    "IDR": "Indonesian Rupiah",
+                    "USD": "US Dollar"
+                }
+                """;
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockBody)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        // When
+        List<FinanceDataResult> results = fetcher.fetch(webClient);
+
+        // Then
+        assertThat(results).hasSize(1);
+
+        FinanceDataResult result = results.get(0);
+        assertThat(result.resourceType()).isEqualTo("supported_currencies");
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> currencies = (Map<String, String>) result.data();
+        assertThat(currencies).hasSize(4);
+        assertThat(currencies).containsEntry("IDR", "Indonesian Rupiah");
+        assertThat(currencies).containsEntry("USD", "US Dollar");
+        assertThat(currencies).containsEntry("EUR", "Euro");
+    }
+
+    @Test
+    @DisplayName("Harus melempar ExternalApiException ketika API mengembalikan error")
+    void shouldThrowExternalApiExceptionOnError() {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(503)
+                .setBody("Service Unavailable"));
+
+        assertThatThrownBy(() -> fetcher.fetch(webClient))
+                .isInstanceOf(ExternalApiException.class);
+    }
+}


### PR DESCRIPTION
Summary
Implements GET /api/finance/data/{resourceType} that aggregates IDR exchange rate data from the Frankfurter public API for 3 resource types: latest_idr_rates, historical_idr_usd, and supported_currencies.
GitHub Username: ramandry12 | Spread Factor: 0.00961 | Tests: 18 passed 

Architectural Rationale
1. Why Strategy Pattern? Each resource type has different fetching logic and transformation rules. Using if/else would violate the Open/Closed Principle — every new resource type would require modifying the service class. With Strategy Pattern, each fetcher is independently encapsulated and Spring injects all implementations into a Map<String, IDRDataFetcher> for zero-conditional dynamic lookup.

2. Why FactoryBean over @Bean? FactoryBean<WebClient> isolates all client construction logic (timeouts, base URL, headers) from the main configuration class, making it independently testable and configurable. Properties are externalized via @ConfigurationProperties, and isSingleton() guarantees a single shared instance.

3. Why ApplicationRunner over @PostConstruct? ApplicationRunner runs after the full ApplicationContext is refreshed, ensuring WebClient and all beans are ready. It also guarantees data is loaded before Tomcat accepts traffic — the app fails fast if the Frankfurter API is unreachable at startup.