### PR TITLE
feat[#173] implement IDR finance data aggregator with strategy pattern, FactoryBean client, startup preload cache, tests, and documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/README.md
+++ b/README.md
@@ -1,139 +1,114 @@
-# Allo Bank Backend Developer Take-Home Test
+# API Integration - Frankfurter (Spring Boot 4, Java 17)
 
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
+## Setup and Run
 
-## 📝 Objective
+1. Clone repository.
+2. Ensure Java 17 is installed.
+3. Build and run tests:
 
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
+```bash
+./mvnw test
+```
 
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
+4. Run app:
 
-## I. Core Task: The Polymorphic API
+```bash
+./mvnw spring-boot:run
+```
 
-### 1. External API Integration (Frankfurter API)
+## Configuration
 
-* **Base URL (Public):** `https://api.frankfurter.app/`.
+Main config is in `src/main/resources/application.yaml`.
 
-* You must integrate with three distinct data resources to enforce the architectural pattern:
+```yaml
+external:
+  frankfurter:
+    base-url: https://api.frankfurter.app
+    connect-timeout-millis: 3000
+    read-timeout-millis: 5000
+    user-agent: ApiIntegration/1.0
 
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
+app:
+  github-username: AmriGIT
+```
 
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
+## Endpoint Usage
 
-   3.  `/currencies` (The list of all supported currency symbols)
+Single exposed endpoint:
 
-### 2. Internal API Endpoint
+- `GET /api/finance/data/{resourceType}`
 
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
+Allowed `resourceType` values:
 
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
+- `latest_idr_rates`
+- `historical_idr_usd`
+- `supported_currencies`
 
-### 3. Required Functionality & Business Logic
+Example cURL:
 
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
+```bash
+curl -s http://localhost:8080/api/finance/data/latest_idr_rates
+curl -s http://localhost:8080/api/finance/data/historical_idr_usd
+curl -s http://localhost:8080/api/finance/data/supported_currencies
+```
 
-* **Data Load:** All three resources should be fetched from the external API.
+## Personalization Note
 
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
+Configured GitLab username: `Amri93`
 
-  **The Spread Factor Must Be Unique :**
+Spread calculation:
 
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
+- Lowercase username: `amri93`
+- Unicode sum: `533`
+- Spread Factor = `(533 % 1000) / 100000.0 = 0.00533`
 
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
+Used formula for `latest_idr_rates`:
 
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
+- `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)`
 
-## II. Architectural Constraints
+## Architectural Rationale
 
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
+### Polymorphism Justification (Strategy Pattern)
 
-### Constraint A: The Strategy Pattern
+`IDRDataFetcher` defines one contract (`resourceType`, `fetch`) and each resource has its own concrete strategy:
 
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
+- `LatestIdrRatesFetcher`
+- `HistoricalIdrUsdFetcher`
+- `SupportedCurrenciesFetcher`
 
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
+Controller uses Spring-injected `Map<String, IDRDataFetcher>` lookup, so adding a new resource only requires adding a new strategy bean. This removes branching complexity from controller/service and improves maintainability.
 
-2.  Implement **three concrete strategy classes** (one for each resource).
+### Client Factory (FactoryBean)
 
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
+External client is created through `FrankfurterRestClientFactoryBean implements FactoryBean<RestClient>`.
 
-### Constraint B: Client Factory Bean
+Benefits:
 
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
+- Centralized client construction with base URL, timeout, and default header configuration.
+- Clean lifecycle/singleton handling for one shared external client instance.
+- Better separation than scattering client setup across services.
 
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
+### Startup Runner Choice (ApplicationRunner)
 
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
+`FinanceDataLoaderRunner` fetches all three resources exactly once at startup and stores them in `FinanceDataInMemoryStore`.
 
-### Constraint C: Startup Data Runner & Immutability
+Why `ApplicationRunner` over `@PostConstruct`:
 
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
+- Runs after the full application context is ready (all strategy beans available).
+- Better control for startup orchestration and testability.
+- Explicit startup ingestion phase, separated from bean initialization concerns.
 
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
-
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
-
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
-
-## III. Production Readiness & Deliverables
-
-Your final solution must demonstrate production quality through code, testing, and communication.
-
-### 1. Robustness & Best Practices
-
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
-
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
-
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
-
-### 2. Testing
-
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
-
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
-
-### 3. Documentation
-
-A clear `README.md` is mandatory. It must include:
-
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
-
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
-
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
-
-* ---
-
-* ### 🛠️ Architectural Rationale
-
-  This section should contain a brief, but detailed, explanation answering the following questions:
-
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
-
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
-
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
-
-## IV. Submission & Review Process
-
-1.  **Fork** this repository.
-
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
-
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
-4.  Please complete the form to submit your technical test: [Click Here](https://forms.gle/nZKQ2EjTCPfAKHog7)
-
-**Your PR will be evaluated on the following:**
-
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
-
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
-
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
-
-Good luck!
+## Data Flow Summary
+
+1. Startup: `ApplicationRunner` executes all `IDRDataFetcher` strategies.
+2. Data is stored once in immutable in-memory map (`Map.copyOf`) in `FinanceDataInMemoryStore`.
+3. Request handling only reads from memory; no per-request external API call.
+
+## Testing Coverage
+
+- Unit tests:
+  - `LatestIdrRatesFetcherTest`
+  - `HistoricalIdrUsdFetcherTest`
+  - `SupportedCurrenciesFetcherTest`
+- Integration test:
+  - `FinanceDataLoaderRunnerIntegrationTest` verifies startup preloads all three resources into the in-memory store.

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.amri</groupId>
+    <artifactId>ApiIntegration</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>ApiIntegration</name>
+    <description>ApiIntegration</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/amri/apiintegration/ApiIntegrationApplication.java
+++ b/src/main/java/com/amri/apiintegration/ApiIntegrationApplication.java
@@ -1,0 +1,15 @@
+package com.amri.apiintegration;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class ApiIntegrationApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ApiIntegrationApplication.class, args);
+    }
+
+}

--- a/src/main/java/com/amri/apiintegration/application/cache/FinanceDataInMemoryStore.java
+++ b/src/main/java/com/amri/apiintegration/application/cache/FinanceDataInMemoryStore.java
@@ -1,0 +1,34 @@
+package com.amri.apiintegration.application.cache;
+
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import com.amri.apiintegration.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+public class FinanceDataInMemoryStore {
+
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private volatile Map<String, FinanceResourceResultDto> resourceData = Map.of();
+
+    public synchronized void initialize(Map<String, FinanceResourceResultDto> loadedData) {
+        if (!initialized.compareAndSet(false, true)) {
+            throw new IllegalStateException("Finance data has already been initialized");
+        }
+        this.resourceData = Map.copyOf(loadedData);
+    }
+
+    public FinanceResourceResultDto getByResourceType(String resourceType) {
+        FinanceResourceResultDto value = resourceData.get(resourceType);
+        if (value == null) {
+            throw new ResourceNotFoundException("Unsupported resourceType: " + resourceType);
+        }
+        return value;
+    }
+
+    public Map<String, FinanceResourceResultDto> snapshot() {
+        return resourceData;
+    }
+}

--- a/src/main/java/com/amri/apiintegration/application/port/CurrencyRatesGateway.java
+++ b/src/main/java/com/amri/apiintegration/application/port/CurrencyRatesGateway.java
@@ -1,0 +1,13 @@
+package com.amri.apiintegration.application.port;
+
+import com.amri.apiintegration.dto.frankfurter.CurrenciesDto;
+import com.amri.apiintegration.dto.frankfurter.HistoricalRatesDto;
+import com.amri.apiintegration.dto.frankfurter.LatestRatesDto;
+
+public interface CurrencyRatesGateway {
+    LatestRatesDto getLatestRates(String base);
+
+    HistoricalRatesDto getHistoricalRates(String startDate, String endDate, String from, String to);
+
+    CurrenciesDto getCurrencies();
+}

--- a/src/main/java/com/amri/apiintegration/application/runner/FinanceDataLoaderRunner.java
+++ b/src/main/java/com/amri/apiintegration/application/runner/FinanceDataLoaderRunner.java
@@ -1,0 +1,29 @@
+package com.amri.apiintegration.application.runner;
+
+import com.amri.apiintegration.application.cache.FinanceDataInMemoryStore;
+import com.amri.apiintegration.application.strategy.IDRDataFetcher;
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class FinanceDataLoaderRunner implements ApplicationRunner {
+
+    private final Map<String, IDRDataFetcher> dataFetchers;
+    private final FinanceDataInMemoryStore inMemoryStore;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Map<String, FinanceResourceResultDto> loadedData = dataFetchers.values()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(IDRDataFetcher::resourceType, IDRDataFetcher::fetch));
+
+        inMemoryStore.initialize(loadedData);
+    }
+}

--- a/src/main/java/com/amri/apiintegration/application/service/SpreadFactorService.java
+++ b/src/main/java/com/amri/apiintegration/application/service/SpreadFactorService.java
@@ -1,0 +1,32 @@
+package com.amri.apiintegration.application.service;
+
+import com.amri.apiintegration.config.ApplicationProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class SpreadFactorService {
+
+    private final ApplicationProperties applicationProperties;
+
+    public BigDecimal getSpreadFactor() {
+        String username = applicationProperties.githubUsername();
+        if (username == null || username.isBlank()) {
+            throw new IllegalStateException("app.github-username must be configured");
+        }
+
+        String normalized = username.toLowerCase(Locale.ROOT);
+        int sum = 0;
+        for (char c : normalized.toCharArray()) {
+            sum += c;
+        }
+
+        return BigDecimal.valueOf(sum % 1000L)
+                .divide(BigDecimal.valueOf(100000L), 5, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/amri/apiintegration/application/strategy/HistoricalIdrUsdFetcher.java
+++ b/src/main/java/com/amri/apiintegration/application/strategy/HistoricalIdrUsdFetcher.java
@@ -1,0 +1,28 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("historical_idr_usd")
+@RequiredArgsConstructor
+public class HistoricalIdrUsdFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "historical_idr_usd";
+
+    private final CurrencyRatesGateway currencyRatesGateway;
+
+    @Override
+    public String resourceType() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
+    public FinanceResourceResultDto fetch() {
+        return new FinanceResourceResultDto(
+                resourceType(),
+                currencyRatesGateway.getHistoricalRates("2024-01-01", "2024-01-05", "IDR", "USD")
+        );
+    }
+}

--- a/src/main/java/com/amri/apiintegration/application/strategy/IDRDataFetcher.java
+++ b/src/main/java/com/amri/apiintegration/application/strategy/IDRDataFetcher.java
@@ -1,0 +1,9 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+
+public interface IDRDataFetcher {
+    String resourceType();
+
+    FinanceResourceResultDto fetch();
+}

--- a/src/main/java/com/amri/apiintegration/application/strategy/LatestIdrRatesFetcher.java
+++ b/src/main/java/com/amri/apiintegration/application/strategy/LatestIdrRatesFetcher.java
@@ -1,0 +1,52 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.application.service.SpreadFactorService;
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import com.amri.apiintegration.dto.frankfurter.LatestRatesDto;
+import com.amri.apiintegration.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+
+@Component("latest_idr_rates")
+@RequiredArgsConstructor
+public class LatestIdrRatesFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "latest_idr_rates";
+
+    private final CurrencyRatesGateway currencyRatesGateway;
+    private final SpreadFactorService spreadFactorService;
+
+    @Override
+    public String resourceType() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
+    public FinanceResourceResultDto fetch() {
+        LatestRatesDto latestRatesDto = currencyRatesGateway.getLatestRates("IDR");
+
+        BigDecimal usdRate = latestRatesDto.rates().get("USD");
+        if (usdRate == null || BigDecimal.ZERO.compareTo(usdRate) == 0) {
+            throw new ResourceNotFoundException("USD rate not available for base IDR");
+        }
+
+        BigDecimal usdBuySpreadIdr = BigDecimal.ONE
+                .divide(usdRate, MathContext.DECIMAL64)
+                .multiply(BigDecimal.ONE.add(spreadFactorService.getSpreadFactor()))
+                .setScale(8, RoundingMode.HALF_UP);
+
+        LatestRatesDto enriched = new LatestRatesDto(
+                latestRatesDto.base(),
+                latestRatesDto.date(),
+                latestRatesDto.rates(),
+                usdBuySpreadIdr
+        );
+
+        return new FinanceResourceResultDto(resourceType(), enriched);
+    }
+}

--- a/src/main/java/com/amri/apiintegration/application/strategy/SupportedCurrenciesFetcher.java
+++ b/src/main/java/com/amri/apiintegration/application/strategy/SupportedCurrenciesFetcher.java
@@ -1,0 +1,25 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component("supported_currencies")
+@RequiredArgsConstructor
+public class SupportedCurrenciesFetcher implements IDRDataFetcher {
+
+    private static final String RESOURCE_TYPE = "supported_currencies";
+
+    private final CurrencyRatesGateway currencyRatesGateway;
+
+    @Override
+    public String resourceType() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
+    public FinanceResourceResultDto fetch() {
+        return new FinanceResourceResultDto(resourceType(), currencyRatesGateway.getCurrencies());
+    }
+}

--- a/src/main/java/com/amri/apiintegration/client/FrankfurterHttpClient.java
+++ b/src/main/java/com/amri/apiintegration/client/FrankfurterHttpClient.java
@@ -1,0 +1,92 @@
+package com.amri.apiintegration.client;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.dto.frankfurter.CurrenciesDto;
+import com.amri.apiintegration.dto.frankfurter.HistoricalRatesDto;
+import com.amri.apiintegration.dto.frankfurter.LatestRatesDto;
+import com.amri.apiintegration.exception.ExternalApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class FrankfurterHttpClient implements CurrencyRatesGateway {
+
+    private final RestClient restClient;
+
+    @Override
+    public LatestRatesDto getLatestRates(String base) {
+        LatestRatesResponse response;
+        try {
+            response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/latest")
+                            .queryParam("base", base)
+                            .build())
+                    .retrieve()
+                    .body(LatestRatesResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new ExternalApiException("Frankfurter latest rates error: HTTP " + e.getStatusCode(), e);
+        } catch (RestClientException e) {
+            throw new ExternalApiException("Frankfurter latest rates network error", e);
+        }
+
+        Objects.requireNonNull(response, "Failed to fetch latest rates from Frankfurter API");
+        return new LatestRatesDto(response.base(), response.date(), response.rates(), null);
+    }
+
+    @Override
+    public HistoricalRatesDto getHistoricalRates(String startDate, String endDate, String from, String to) {
+        HistoricalRatesResponse response;
+        try {
+            response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/{range}")
+                            .queryParam("from", from)
+                            .queryParam("to", to)
+                            .build(startDate + ".." + endDate))
+                    .retrieve()
+                    .body(HistoricalRatesResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new ExternalApiException("Frankfurter historical rates error: HTTP " + e.getStatusCode(), e);
+        } catch (RestClientException e) {
+            throw new ExternalApiException("Frankfurter historical rates network error", e);
+        }
+
+        Objects.requireNonNull(response, "Failed to fetch historical rates from Frankfurter API");
+        return new HistoricalRatesDto(response.amount(), response.base(), response.rates());
+    }
+
+    @Override
+    public CurrenciesDto getCurrencies() {
+        Map<String, String> response;
+        try {
+            response = restClient.get()
+                    .uri("/currencies")
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<>() {
+                    });
+        } catch (RestClientResponseException e) {
+            throw new ExternalApiException("Frankfurter currencies error: HTTP " + e.getStatusCode(), e);
+        } catch (RestClientException e) {
+            throw new ExternalApiException("Frankfurter currencies network error", e);
+        }
+
+        Objects.requireNonNull(response, "Failed to fetch currencies from Frankfurter API");
+        return new CurrenciesDto(response);
+    }
+
+    record LatestRatesResponse(String base, String date, Map<String, BigDecimal> rates) {
+    }
+
+    record HistoricalRatesResponse(BigDecimal amount, String base, Map<String, Map<String, BigDecimal>> rates) {
+    }
+}

--- a/src/main/java/com/amri/apiintegration/config/ApplicationProperties.java
+++ b/src/main/java/com/amri/apiintegration/config/ApplicationProperties.java
@@ -1,0 +1,7 @@
+package com.amri.apiintegration.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+public record ApplicationProperties(String githubUsername) {
+}

--- a/src/main/java/com/amri/apiintegration/config/FrankfurterProperties.java
+++ b/src/main/java/com/amri/apiintegration/config/FrankfurterProperties.java
@@ -1,0 +1,15 @@
+package com.amri.apiintegration.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "external.frankfurter")
+@Getter
+@Setter
+public class FrankfurterProperties {
+    private String baseUrl;
+    private int connectTimeoutMillis = 3000;
+    private int readTimeoutMillis = 5000;
+    private String userAgent = "ApiIntegration/1.0";
+}

--- a/src/main/java/com/amri/apiintegration/config/FrankfurterRestClientFactoryBean.java
+++ b/src/main/java/com/amri/apiintegration/config/FrankfurterRestClientFactoryBean.java
@@ -1,0 +1,46 @@
+package com.amri.apiintegration.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component("frankfurterRestClient")
+@RequiredArgsConstructor
+public class FrankfurterRestClientFactoryBean implements FactoryBean<RestClient> {
+
+    private final FrankfurterProperties frankfurterProperties;
+    private volatile RestClient restClient;
+
+    @Override
+    public RestClient getObject() {
+        if (restClient == null) {
+            synchronized (this) {
+                if (restClient == null) {
+                    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+                    requestFactory.setConnectTimeout(frankfurterProperties.getConnectTimeoutMillis());
+                    requestFactory.setReadTimeout(frankfurterProperties.getReadTimeoutMillis());
+
+                    restClient = RestClient.builder()
+                            .baseUrl(frankfurterProperties.getBaseUrl())
+                            .defaultHeader(HttpHeaders.USER_AGENT, frankfurterProperties.getUserAgent())
+                            .requestFactory(requestFactory)
+                            .build();
+                }
+            }
+        }
+        return restClient;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return RestClient.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/amri/apiintegration/dto/frankfurter/CurrenciesDto.java
+++ b/src/main/java/com/amri/apiintegration/dto/frankfurter/CurrenciesDto.java
@@ -1,0 +1,6 @@
+package com.amri.apiintegration.dto.frankfurter;
+
+import java.util.Map;
+
+public record CurrenciesDto(Map<String, String> currencies) implements FinanceDataDto {
+}

--- a/src/main/java/com/amri/apiintegration/dto/frankfurter/FinanceDataDto.java
+++ b/src/main/java/com/amri/apiintegration/dto/frankfurter/FinanceDataDto.java
@@ -1,0 +1,4 @@
+package com.amri.apiintegration.dto.frankfurter;
+
+public interface FinanceDataDto {
+}

--- a/src/main/java/com/amri/apiintegration/dto/frankfurter/FinanceResourceResultDto.java
+++ b/src/main/java/com/amri/apiintegration/dto/frankfurter/FinanceResourceResultDto.java
@@ -1,0 +1,4 @@
+package com.amri.apiintegration.dto.frankfurter;
+
+public record FinanceResourceResultDto(String resourceType, FinanceDataDto data) {
+}

--- a/src/main/java/com/amri/apiintegration/dto/frankfurter/HistoricalRatesDto.java
+++ b/src/main/java/com/amri/apiintegration/dto/frankfurter/HistoricalRatesDto.java
@@ -1,0 +1,7 @@
+package com.amri.apiintegration.dto.frankfurter;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record HistoricalRatesDto(BigDecimal amount, String base, Map<String, Map<String, BigDecimal>> rates) implements FinanceDataDto {
+}

--- a/src/main/java/com/amri/apiintegration/dto/frankfurter/LatestRatesDto.java
+++ b/src/main/java/com/amri/apiintegration/dto/frankfurter/LatestRatesDto.java
@@ -1,0 +1,14 @@
+package com.amri.apiintegration.dto.frankfurter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public record LatestRatesDto(
+        String base,
+        String date,
+        Map<String, BigDecimal> rates,
+        @JsonProperty("USD_BuySpread_IDR") BigDecimal usdBuySpreadIdr
+) implements FinanceDataDto {
+}

--- a/src/main/java/com/amri/apiintegration/endpoint/IFrakturterEndpoint.java
+++ b/src/main/java/com/amri/apiintegration/endpoint/IFrakturterEndpoint.java
@@ -1,0 +1,16 @@
+package com.amri.apiintegration.endpoint;
+
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import com.amri.apiintegration.util.IResultDTO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@RequestMapping("/api/finance/data")
+public interface IFrakturterEndpoint {
+
+    @GetMapping("/{resourceType}")
+    IResultDTO<List<FinanceResourceResultDto>> getFinanceData(@PathVariable String resourceType);
+}

--- a/src/main/java/com/amri/apiintegration/endpoint/impl/IFraktureterEndpointImpl.java
+++ b/src/main/java/com/amri/apiintegration/endpoint/impl/IFraktureterEndpointImpl.java
@@ -1,0 +1,31 @@
+package com.amri.apiintegration.endpoint.impl;
+
+import com.amri.apiintegration.application.cache.FinanceDataInMemoryStore;
+import com.amri.apiintegration.application.strategy.IDRDataFetcher;
+import com.amri.apiintegration.dto.frankfurter.FinanceResourceResultDto;
+import com.amri.apiintegration.endpoint.IFrakturterEndpoint;
+import com.amri.apiintegration.exception.ResourceNotFoundException;
+import com.amri.apiintegration.util.IResultDTO;
+import com.amri.apiintegration.util.ResponseBuilderAPI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+public class IFraktureterEndpointImpl implements IFrakturterEndpoint {
+
+    private final Map<String, IDRDataFetcher> dataFetchers;
+    private final FinanceDataInMemoryStore inMemoryStore;
+
+    @Override
+    public IResultDTO<List<FinanceResourceResultDto>> getFinanceData(String resourceType) {
+        IDRDataFetcher fetcher = Optional.ofNullable(dataFetchers.get(resourceType))
+                .orElseThrow(() -> new ResourceNotFoundException("Unsupported resourceType: " + resourceType));
+
+        return ResponseBuilderAPI.ok(List.of(inMemoryStore.getByResourceType(fetcher.resourceType())));
+    }
+}

--- a/src/main/java/com/amri/apiintegration/exception/ExternalApiException.java
+++ b/src/main/java/com/amri/apiintegration/exception/ExternalApiException.java
@@ -1,0 +1,11 @@
+package com.amri.apiintegration.exception;
+
+public class ExternalApiException extends RuntimeException {
+    public ExternalApiException(String message) {
+        super(message);
+    }
+
+    public ExternalApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/amri/apiintegration/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/amri/apiintegration/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.amri.apiintegration.exception;
+
+import com.amri.apiintegration.util.IResultDTO;
+import com.amri.apiintegration.util.ResponseBuilderAPI;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ExternalApiException.class)
+    @ResponseStatus(value = HttpStatus.BAD_GATEWAY)
+    public IResultDTO<Object> externalApi(ExternalApiException e) {
+        return ResponseBuilderAPI.error(HttpStatus.BAD_GATEWAY.value(), e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    public IResultDTO<Object> handle(HttpServletRequest req, Exception e) {
+        return ResponseBuilderAPI.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), e);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public IResultDTO<Object> resourceNotFound(ResourceNotFoundException e, WebRequest request) {
+        return ResponseBuilderAPI.error(HttpStatus.NOT_FOUND.value(), e.getMessage());
+    }
+}

--- a/src/main/java/com/amri/apiintegration/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/amri/apiintegration/exception/ResourceNotFoundException.java
@@ -1,0 +1,18 @@
+package com.amri.apiintegration.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Resource not found")
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+    }
+
+    public ResourceNotFoundException(String resourceName, Long id) {
+        super(String.format("%s not found with id : %d", resourceName, id));
+    }
+}

--- a/src/main/java/com/amri/apiintegration/statval/UriConstant.java
+++ b/src/main/java/com/amri/apiintegration/statval/UriConstant.java
@@ -1,0 +1,15 @@
+package com.amri.apiintegration.statval;
+
+public class UriConstant {
+    public static final String V1 = "/v1";
+    public static final String API = "/api";
+    public static final String ENDPOINT = API + V1;
+    public static final String FINDALL = "/findall";
+    public static final String PAGINATION = "/{page}/{size}";
+    public static final String FINDBYID = "/{id}";
+    public static final String SEARCH = "/search";
+
+    public static class ClassEndpoint{
+        public static final String FRANKFURTER = "/frankfurter";
+    }
+}

--- a/src/main/java/com/amri/apiintegration/util/GenericMapper.java
+++ b/src/main/java/com/amri/apiintegration/util/GenericMapper.java
@@ -1,0 +1,21 @@
+package com.amri.apiintegration.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public interface GenericMapper<E,D> {
+    D toDto(E entity);
+    E toEntity(D dto);
+
+    default List<D> toDto(List<E> entityList){
+        return entityList.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    default List<E>toEntity(List<D> dtoList){
+        return dtoList.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/amri/apiintegration/util/IResultDTO.java
+++ b/src/main/java/com/amri/apiintegration/util/IResultDTO.java
@@ -1,0 +1,24 @@
+package com.amri.apiintegration.util;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonPropertyOrder({"status", "message", "data", "metadata"})
+public class IResultDTO<T> {
+    private int status;
+    private String message;
+    private T data;
+    private Metadata metadata;
+
+
+    public IResultDTO(int status, String message, T data){
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/amri/apiintegration/util/Metadata.java
+++ b/src/main/java/com/amri/apiintegration/util/Metadata.java
@@ -1,0 +1,10 @@
+package com.amri.apiintegration.util;
+
+import lombok.Builder;
+
+@Builder
+public class Metadata {
+    private int page;
+    private int size;
+    private int totalPage;
+}

--- a/src/main/java/com/amri/apiintegration/util/ResponseBuilderAPI.java
+++ b/src/main/java/com/amri/apiintegration/util/ResponseBuilderAPI.java
@@ -1,0 +1,23 @@
+package com.amri.apiintegration.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ResponseBuilderAPI {
+    public static <T> IResultDTO<T> ok(T data) {
+        return new IResultDTO<>(HttpStatus.OK.value(), "Success", data);
+    }
+
+    public static <T> IResultDTO<T> error(int status, Exception e) {
+        e.printStackTrace();
+        return new IResultDTO<>(status, e.getMessage(), null);
+    }
+
+    public static <T> IResultDTO<T> error(int status, String message) {
+        return new IResultDTO<>(status, message, null);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: ApiIntegration
+
+external:
+  frankfurter:
+    base-url: https://api.frankfurter.app
+    connect-timeout-millis: 3000
+    read-timeout-millis: 5000
+    user-agent: ApiIntegration/1.0
+
+app:
+  github-username: AmriGIT

--- a/src/test/java/com/amri/apiintegration/ApiIntegrationApplicationTests.java
+++ b/src/test/java/com/amri/apiintegration/ApiIntegrationApplicationTests.java
@@ -1,0 +1,13 @@
+package com.amri.apiintegration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApiIntegrationApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/src/test/java/com/amri/apiintegration/application/runner/FinanceDataLoaderRunnerIntegrationTest.java
+++ b/src/test/java/com/amri/apiintegration/application/runner/FinanceDataLoaderRunnerIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.amri.apiintegration.application.runner;
+
+import com.amri.apiintegration.application.cache.FinanceDataInMemoryStore;
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.dto.frankfurter.CurrenciesDto;
+import com.amri.apiintegration.dto.frankfurter.HistoricalRatesDto;
+import com.amri.apiintegration.dto.frankfurter.LatestRatesDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(properties = {
+        "app.github-username=AmriGIT",
+        "external.frankfurter.base-url=https://api.frankfurter.app"
+})
+class FinanceDataLoaderRunnerIntegrationTest {
+
+    @TestConfiguration
+    static class MockGatewayConfig {
+        @Bean
+        @Primary
+        CurrencyRatesGateway currencyRatesGateway() {
+            return new CurrencyRatesGateway() {
+                @Override
+                public LatestRatesDto getLatestRates(String base) {
+                    return new LatestRatesDto(base, "2026-02-26", Map.of("USD", new BigDecimal("0.00006150")), null);
+                }
+
+                @Override
+                public HistoricalRatesDto getHistoricalRates(String startDate, String endDate, String from, String to) {
+                    return new HistoricalRatesDto(
+                            BigDecimal.ONE,
+                            from,
+                            Map.of(startDate, Map.of(to, new BigDecimal("0.000064")))
+                    );
+                }
+
+                @Override
+                public CurrenciesDto getCurrencies() {
+                    return new CurrenciesDto(Map.of("USD", "United States Dollar"));
+                }
+            };
+        }
+    }
+
+    @Autowired
+    private FinanceDataInMemoryStore inMemoryStore;
+
+    @Test
+    void startupRunner_shouldLoadAllResourcesIntoImmutableStore() {
+        Map<String, ?> snapshot = inMemoryStore.snapshot();
+
+        assertEquals(3, snapshot.size());
+        assertTrue(snapshot.containsKey("latest_idr_rates"));
+        assertTrue(snapshot.containsKey("historical_idr_usd"));
+        assertTrue(snapshot.containsKey("supported_currencies"));
+    }
+}

--- a/src/test/java/com/amri/apiintegration/application/strategy/HistoricalIdrUsdFetcherTest.java
+++ b/src/test/java/com/amri/apiintegration/application/strategy/HistoricalIdrUsdFetcherTest.java
@@ -1,0 +1,41 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.dto.frankfurter.HistoricalRatesDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HistoricalIdrUsdFetcherTest {
+
+    @Mock
+    private CurrencyRatesGateway currencyRatesGateway;
+
+    @Test
+    void fetch_shouldReturnHistoricalPayloadForConfiguredDateRange() {
+        HistoricalRatesDto historicalRatesDto = new HistoricalRatesDto(
+                BigDecimal.ONE,
+                "IDR",
+                Map.of("2024-01-01", Map.of("USD", new BigDecimal("0.000064")))
+        );
+        when(currencyRatesGateway.getHistoricalRates("2024-01-01", "2024-01-05", "IDR", "USD"))
+                .thenReturn(historicalRatesDto);
+
+        HistoricalIdrUsdFetcher fetcher = new HistoricalIdrUsdFetcher(currencyRatesGateway);
+
+        var result = fetcher.fetch();
+
+        assertEquals("historical_idr_usd", result.resourceType());
+        assertEquals(historicalRatesDto, result.data());
+        verify(currencyRatesGateway).getHistoricalRates("2024-01-01", "2024-01-05", "IDR", "USD");
+    }
+}

--- a/src/test/java/com/amri/apiintegration/application/strategy/LatestIdrRatesFetcherTest.java
+++ b/src/test/java/com/amri/apiintegration/application/strategy/LatestIdrRatesFetcherTest.java
@@ -1,0 +1,44 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.application.service.SpreadFactorService;
+import com.amri.apiintegration.config.ApplicationProperties;
+import com.amri.apiintegration.dto.frankfurter.LatestRatesDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LatestIdrRatesFetcherTest {
+
+    @Mock
+    private CurrencyRatesGateway currencyRatesGateway;
+
+    @Test
+    void fetch_shouldCalculateUsdBuySpreadIdrAndWrapResult() {
+        when(currencyRatesGateway.getLatestRates("IDR")).thenReturn(
+                new LatestRatesDto(
+                        "IDR",
+                        "2026-02-26",
+                        Map.of("USD", new BigDecimal("0.00006150")),
+                        null
+                )
+        );
+
+        SpreadFactorService spreadFactorService = new SpreadFactorService(new ApplicationProperties("Amri93"));
+        LatestIdrRatesFetcher fetcher = new LatestIdrRatesFetcher(currencyRatesGateway, spreadFactorService);
+
+        var result = fetcher.fetch();
+        var data = (LatestRatesDto) result.data();
+
+        assertEquals("latest_idr_rates", result.resourceType());
+        assertEquals(new BigDecimal("16346.82926829"), data.usdBuySpreadIdr());
+    }
+}

--- a/src/test/java/com/amri/apiintegration/application/strategy/SupportedCurrenciesFetcherTest.java
+++ b/src/test/java/com/amri/apiintegration/application/strategy/SupportedCurrenciesFetcherTest.java
@@ -1,0 +1,35 @@
+package com.amri.apiintegration.application.strategy;
+
+import com.amri.apiintegration.application.port.CurrencyRatesGateway;
+import com.amri.apiintegration.dto.frankfurter.CurrenciesDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SupportedCurrenciesFetcherTest {
+
+    @Mock
+    private CurrencyRatesGateway currencyRatesGateway;
+
+    @Test
+    void fetch_shouldReturnSupportedCurrencies() {
+        CurrenciesDto currenciesDto = new CurrenciesDto(Map.of("USD", "United States Dollar"));
+        when(currencyRatesGateway.getCurrencies()).thenReturn(currenciesDto);
+
+        SupportedCurrenciesFetcher fetcher = new SupportedCurrenciesFetcher(currencyRatesGateway);
+
+        var result = fetcher.fetch();
+
+        assertEquals("supported_currencies", result.resourceType());
+        assertEquals(currenciesDto, result.data());
+        verify(currencyRatesGateway).getCurrencies();
+    }
+}


### PR DESCRIPTION
# API Integration - Frankfurter (Spring Boot 4, Java 17)

## Setup and Run

1. Clone repository.
2. Ensure Java 17 is installed.
3. Build and run tests:

```bash
./mvnw test
```

4. Run app:

```bash
./mvnw spring-boot:run
```

## Configuration

Main config is in `src/main/resources/application.yaml`.

```yaml
external:
  frankfurter:
    base-url: https://api.frankfurter.app
    connect-timeout-millis: 3000
    read-timeout-millis: 5000
    user-agent: ApiIntegration/1.0

app:
  github-username: AmriGIT
```

## Endpoint Usage

Single exposed endpoint:

- `GET /api/finance/data/{resourceType}`

Allowed `resourceType` values:

- `latest_idr_rates`
- `historical_idr_usd`
- `supported_currencies`

Example cURL:

```bash
curl -s http://localhost:8080/api/finance/data/latest_idr_rates
curl -s http://localhost:8080/api/finance/data/historical_idr_usd
curl -s http://localhost:8080/api/finance/data/supported_currencies
```

## Personalization Note

Configured GitLab username: `Amri93`

Spread calculation:

- Lowercase username: `amri93`
- Unicode sum: `533`
- Spread Factor = `(533 % 1000) / 100000.0 = 0.00533`

Used formula for `latest_idr_rates`:

- `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)`

## Architectural Rationale

### Polymorphism Justification (Strategy Pattern)

`IDRDataFetcher` defines one contract (`resourceType`, `fetch`) and each resource has its own concrete strategy:

- `LatestIdrRatesFetcher`
- `HistoricalIdrUsdFetcher`
- `SupportedCurrenciesFetcher`

Controller uses Spring-injected `Map<String, IDRDataFetcher>` lookup, so adding a new resource only requires adding a new strategy bean. This removes branching complexity from controller/service and improves maintainability.

### Client Factory (FactoryBean)

External client is created through `FrankfurterRestClientFactoryBean implements FactoryBean<RestClient>`.

Benefits:

- Centralized client construction with base URL, timeout, and default header configuration.
- Clean lifecycle/singleton handling for one shared external client instance.
- Better separation than scattering client setup across services.

### Startup Runner Choice (ApplicationRunner)

`FinanceDataLoaderRunner` fetches all three resources exactly once at startup and stores them in `FinanceDataInMemoryStore`.

Why `ApplicationRunner` over `@PostConstruct`:

- Runs after the full application context is ready (all strategy beans available).
- Better control for startup orchestration and testability.
- Explicit startup ingestion phase, separated from bean initialization concerns.

## Data Flow Summary

1. Startup: `ApplicationRunner` executes all `IDRDataFetcher` strategies.
2. Data is stored once in immutable in-memory map (`Map.copyOf`) in `FinanceDataInMemoryStore`.
3. Request handling only reads from memory; no per-request external API call.

## Testing Coverage

- Unit tests:
  - `LatestIdrRatesFetcherTest`
  - `HistoricalIdrUsdFetcherTest`
  - `SupportedCurrenciesFetcherTest`
- Integration test:
  - `FinanceDataLoaderRunnerIntegrationTest` verifies startup preloads all three resources into the in-memory store.
