### PR TITLE
feat: IDR Rate Aggregator Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,87 @@
-# Allo Bank Backend Developer Take-Home Test
+# Polymorphic Finance API
 
-Thank you for applying to our team! This take-home test is designed to evaluate your practical skills in building **production-ready** Spring Boot applications within a finance domain, focusing on architectural patterns and complex data handling.
+This project is a Spring Boot application that demonstrates the use of several advanced architectural patterns to create a robust and extensible API. It integrates with the Frankfurter API to fetch financial data, processes it, and exposes it through a single, polymorphic endpoint.
 
-## 📝 Objective
+## Setup and Run
 
-Your task is to create a single Spring Boot REST API endpoint capable of aggregating data from multiple, distinct resources provided by the public, keyless **Frankfurter Exchange Rate API**. The primary focus is on handling Indonesian Rupiah (IDR) data.
+1.  **Prerequisites**:
+    *   Java 17 or higher
+    *   Maven or Gradle
 
-The focus of this test is not just functional correctness, but demonstrating clean code, advanced Spring concepts, thread-safe design, and architectural clarity.
+2.  **Build the project**:
+    ```bash
+    # Using Maven
+    mvn clean install
 
-## I. Core Task: The Polymorphic API
+    # Using Gradle
+    gradle clean build
+    ```
 
-### 1. External API Integration (Frankfurter API)
+3.  **Run the application**:
+    ```bash
+    # Using Maven
+    mvn spring-boot:run
 
-* **Base URL (Public):** `https://api.frankfurter.app/`.
+    # Using Gradle
+    gradle bootRun
+    ```
 
-* You must integrate with three distinct data resources to enforce the architectural pattern:
+The application will start on port 8080.
 
-   1.  `/latest?base=IDR` (The latest rates relative to IDR)
+## Endpoint Usage
 
-   2.  **Historical Data:** Query a specific, small time series (e.g., `/2024-01-01..2024-01-05?from=IDR&to=USD`). **Note:** *Use the date range provided in this example unless a different range is communicated separately.*
+The single endpoint `GET /api/finance/data/{resourceType}` serves all data. Replace `{resourceType}` with one of the following values:
 
-   3.  `/currencies` (The list of all supported currency symbols)
+*   `latest_idr_rates`
+*   `historical_idr_usd`
+*   `supported_currencies`
 
-### 2. Internal API Endpoint
+### Example cURL Commands
 
-You must expose **one single endpoint** in your application: ```GET /api/finance/data/{resourceType}```
+**1. Get Latest Rates (base IDR) with Spread Calculation**
+```bash
+curl http://localhost:8080/api/finance/data/latest_idr_rates
+```
 
-Where `{resourceType}` can be one of the three strings: `latest_idr_rates`, `historical_idr_usd`, or `supported_currencies`.
+**2. Get Historical Rates (IDR to USD)**
+```bash
+curl http://localhost:8080/api/finance/data/historical_idr_usd
+```
 
-### 3. Required Functionality & Business Logic
+**3. Get Supported Currencies**
+```bash
+curl http://localhost:8080/api/finance/data/supported_currencies
+```
 
-* **Resource Handling:** Your service must correctly map the three incoming `resourceType` values to the correct data fetching strategies.
+## Personalization Note
 
-* **Data Load:** All three resources should be fetched from the external API.
+*   **GitHub Username**: `rakuszz0`
+*   **Calculated Spread Factor**: `0.00842`
 
-* **Data Transformation (Latest IDR Rates only) - Unique Calculation:** For the **`latest_idr_rates`** resource, you must calculate and include a new field, `"USD_BuySpread_IDR"`. This is the Rupiah selling rate to USD after applying a banking spread/margin.
+This factor is used in the calculation of the `USD_BuySpread_IDR` field for the `latest_idr_rates` resource.
 
-  **The Spread Factor Must Be Unique :**
+## Architectural Rationale
 
-   1.  **Input:** Your GitHub username (e.g., `johndoe47`).
-   2.  **Calculation:** Calculate the sum of the Unicode (ASCII) values of all characters in your lowercase GitHub username string.
-   3.  **Spread Factor Derivation:** `Spread Factor = (Sum of Unicode Values % 1000) / 100000.0`
-       *(This will yield a unique factor between 0.00000 and 0.00999, ensuring a personalized result.)*
+### Polymorphism Justification: The Strategy Pattern
 
-  **Final Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + Spread Factor)` (where `Rate_USD` is the value from the API when `base=IDR`).
+The Strategy Pattern was chosen to handle the different data resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) for several key reasons:
 
-* **Other Resources:** The `historical_idr_usd` and `supported_currencies` resources can return their data with minimal transformation, but the final output must be a unified JSON array of results.
+*   **Extensibility**: Adding a new data resource is as simple as creating a new class that implements the `DataFetcherStrategy` interface. The core logic of the application does not need to be modified. This adheres to the Open/Closed Principle.
+*   **Maintainability**: Each strategy is self-contained and responsible for a single piece of functionality. This makes the code easier to read, understand, and test.
+*   **Decoupling**: The `FinanceController` is completely decoupled from the implementation details of how the data is fetched. It simply delegates the task to the appropriate strategy, which is resolved at runtime by Spring's dependency injection mechanism. This avoids a chain of `if/else` or `switch` statements, which would become unwieldy as more resources are added.
 
-## II. Architectural Constraints
+### Client Factory: The `FactoryBean`
 
-Meeting the core task is only one part of the solution. The following constraints must be strictly adhered to and will be heavily weighted during evaluation:
+A `FactoryBean` was used to create the `WebClient` instance for the following reasons:
 
-### Constraint A: The Strategy Pattern
+*   **Encapsulation of Complex Initialization**: The `FactoryBean` encapsulates the logic for creating and configuring the `WebClient`. This is particularly useful if the client requires more complex setup, such as setting default headers, timeouts, or filters. By centralizing this logic, we avoid cluttering our `@Configuration` classes.
+*   **Separation of Concerns**: The `FactoryBean`'s sole responsibility is to create the `WebClient`. This is a cleaner approach than defining a `@Bean` method directly in a configuration class, especially when the creation logic is non-trivial.
+*   **Lazy Initialization**: While not explicitly configured here, a `FactoryBean` can provide more control over the bean's lifecycle, including lazy initialization.
 
-The logic for handling the three different resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) must be implemented using the **Strategy Design Pattern**.
+### Startup Runner Choice: `ApplicationRunner`
 
-1.  Define a clear **Strategy Interface** (e.g., `IDRDataFetcher`).
+An `ApplicationRunner` was used for the initial data ingestion for these reasons:
 
-2.  Implement **three concrete strategy classes** (one for each resource).
-
-3.  The main `Controller` should dynamically select the correct strategy implementation using a map-based lookup injected by Spring, avoiding any manual `if/else` or `switch` logic in the controller layer.
-
-### Constraint B: Client Factory Bean
-
-The instance of your chosen external API client (`WebClient` or `RestTemplate`) **must be defined and created within a custom implementation of Spring's `FactoryBean<T>` interface**.
-
-* This `FactoryBean` should be responsible for externalizing the API Base URL via `@Value` or `@ConfigurationProperties` and applying any initial configuration (e.g., timeouts, shared headers).
-
-* ***You may not define the client as a simple `@Bean` in a `@Configuration` class.***
-
-### Constraint C: Startup Data Runner & Immutability
-
-The aggregated data for **ALL three resources** must be fetched **exactly once on application startup** and loaded into an in-memory store.
-
-1.  Use a Spring Boot **`ApplicationRunner`** or **`CommandLineRunner`** component to initiate the data fetching process.
-
-2.  The API endpoint (`GET /api/finance/data/{resourceType}`) must serve the data from this **in-memory store**, not by making a new call to the external API on every request.
-
-3.  The in-memory storage mechanism (e.g., a service holding the data) must be designed to be **thread-safe** and ensure the data is **immutable** once the `ApplicationRunner` has finished loading it.
-
-## III. Production Readiness & Deliverables
-
-Your final solution must demonstrate production quality through code, testing, and communication.
-
-### 1. Robustness & Best Practices
-
-* Graceful **Error Handling** for network failures or 4xx/5xx responses from the external API.
-
-* Proper use of **Configuration Properties** (e.g., `application.yml`) for external service URLs.
-
-* Clear separation of concerns (Controller, Service, Model/DTO, etc.).
-
-### 2. Testing
-
-* **Unit Tests** for all three `IDRDataFetcher` strategy implementations, ensuring data calculation and transformation logic is covered (using mock clients for external calls).
-
-* **Integration Tests** to verify the `ApplicationRunner` successfully initializes and loads the data into the in-memory store before the application context is ready.
-
-### 3. Documentation
-
-A clear `README.md` is mandatory. It must include:
-
-* **Setup/Run Instructions:** Clear steps to clone, build, and run the application and tests.
-
-* **Endpoint Usage:** Example cURL commands to test the three different resource types.
-
-* **Personalization Note:** Clearly state your GitHub username and show the exact **Spread Factor** (e.g., `0.00765`) calculated by your function.
-
-* ---
-
-* ### 🛠️ Architectural Rationale
-
-  This section should contain a brief, but detailed, explanation answering the following questions:
-
-   1.  **Polymorphism Justification:** Explain *why* the Strategy Pattern was used over a simpler conditional block in the service layer for handling the multi-resource endpoint. Discuss the benefits in terms of **extensibility** and **maintainability**.
-
-   2.  **Client Factory:** Explain the specific role and benefit of using a **`FactoryBean`** to construct the external API client. Why is this preferable to defining the client using a standard `@Bean` method in this scenario?
-
-   3.  **Startup Runner Choice:** Justify the choice of using an `ApplicationRunner` (or `CommandLineRunner`) for the initial data ingestion over a simpler `@PostConstruct` method.
-
-## IV. Submission & Review Process
-
-1.  **Fork** this repository.
-
-2.  Implement your solution on a dedicated feature branch (e.g., `feat/idr-rate-aggregator`).
-
-3.  When complete, submit your solution via a **Pull Request (PR)** back to the main repository.
-4.  Please complete the form to submit your technical test: [Click Here](https://forms.gle/nZKQ2EjTCPfAKHog7)
-
-**Your PR will be evaluated on the following:**
-
-* **Commit History:** Clean, atomic, and descriptive commit messages (e.g., "feat: Implement IDR latest rates strategy," "fix: Correctly calculate IDR spread in tests").
-
-* **PR Description:** The description must clearly summarize the solution and **must contain the full answers** to the three "Architectural Rationale" questions from Section III.
-
-* **Code Review Readiness:** The code should be well-structured and ready for immediate review.
-
-Good luck!
+*   **Guaranteed Execution Order**: `ApplicationRunner` (and `CommandLineRunner`) beans are executed after the application context has been fully initialized but before the application is ready to accept requests. This ensures that the in-memory data store is populated before any client can access the API.
+*   **Separation from Bean Lifecycle**: Using `@PostConstruct` on a service method would tie the data loading logic to the lifecycle of that specific bean. An `ApplicationRunner` is a more explicit and dedicated component for startup tasks, making the application's bootstrap process clearer.
+*   **Access to Application Arguments**: `ApplicationRunner` provides access to command-line arguments, which can be useful for more advanced configuration scenarios.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.allobank</groupId>
+    <artifactId>finance-api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>finance-api</name>
+    <description>Demo project for Spring Boot</description>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <classifier>osx-aarch_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <classifier>osx-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.14.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <argLine>-Djava.version=${java.version} -Dnet.bytebuddy.experimental=true --enable-native-access=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/allobank/financeapi/FinanceApiApplication.java
+++ b/src/main/java/com/allobank/financeapi/FinanceApiApplication.java
@@ -1,0 +1,11 @@
+package com.allobank.financeapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FinanceApiApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FinanceApiApplication.class, args);
+    }
+}

--- a/src/main/java/com/allobank/financeapi/config/WebClientFactoryBean.java
+++ b/src/main/java/com/allobank/financeapi/config/WebClientFactoryBean.java
@@ -1,0 +1,30 @@
+package com.allobank.financeapi.config;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component("frankfurterWebClient")
+public class WebClientFactoryBean implements FactoryBean<WebClient> {
+
+    @Value("${api.frankfurter.baseUrl}")
+    private String baseUrl;
+
+    @Override
+    public WebClient getObject() throws Exception {
+        return WebClient.builder()
+                .baseUrl(this.baseUrl)
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/allobank/financeapi/controller/FinanceController.java
+++ b/src/main/java/com/allobank/financeapi/controller/FinanceController.java
@@ -1,0 +1,32 @@
+package com.allobank.financeapi.controller;
+
+import com.allobank.financeapi.model.enums.ResourceType;
+import com.allobank.financeapi.service.FinanceDataService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/finance/data")
+public class FinanceController {
+
+    private final FinanceDataService financeDataService;
+
+    public FinanceController(FinanceDataService financeDataService) {
+        this.financeDataService = financeDataService;
+    }
+
+    @GetMapping("/{resourceType}")
+    public ResponseEntity<Object> getFinanceData(@PathVariable String resourceType) {
+        try {
+            ResourceType type = ResourceType.fromValue(resourceType);
+            return this.financeDataService.getData(type)
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/allobank/financeapi/controller/TestController.java
+++ b/src/main/java/com/allobank/financeapi/controller/TestController.java
@@ -1,0 +1,18 @@
+package com.allobank.financeapi.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+    
+    @GetMapping("/test")
+    public String test() {
+        return "✅ Allo Bank API is running with JDK 17!";
+    }
+    
+    @GetMapping("/info")
+    public String info() {
+        return "Java Version: " + System.getProperty("java.version");
+    }
+}

--- a/src/main/java/com/allobank/financeapi/model/dto/HistoricalRatesResponse.java
+++ b/src/main/java/com/allobank/financeapi/model/dto/HistoricalRatesResponse.java
@@ -1,0 +1,51 @@
+package com.allobank.financeapi.model.dto;
+
+import java.util.Map;
+
+public class HistoricalRatesResponse {
+    private double amount;
+    private String base;
+    private String start_date;
+    private String end_date;
+    private Map<String, Map<String, Double>> rates;
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public String getBase() {
+        return base;
+    }
+
+    public void setBase(String base) {
+        this.base = base;
+    }
+
+    public String getStart_date() {
+        return start_date;
+    }
+
+    public void setStart_date(String start_date) {
+        this.start_date = start_date;
+    }
+
+    public String getEnd_date() {
+        return end_date;
+    }
+
+    public void setEnd_date(String end_date) {
+        this.end_date = end_date;
+    }
+
+    public Map<String, Map<String, Double>> getRates() {
+        return rates;
+    }
+
+    public void setRates(Map<String, Map<String, Double>> rates) {
+        this.rates = rates;
+    }
+}

--- a/src/main/java/com/allobank/financeapi/model/dto/LatestRatesResponse.java
+++ b/src/main/java/com/allobank/financeapi/model/dto/LatestRatesResponse.java
@@ -1,0 +1,51 @@
+package com.allobank.financeapi.model.dto;
+
+import java.util.Map;
+
+public class LatestRatesResponse {
+    private double amount;
+    private String base;
+    private String date;
+    private Map<String, Double> rates;
+    private Double USD_BuySpread_IDR;
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public String getBase() {
+        return base;
+    }
+
+    public void setBase(String base) {
+        this.base = base;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    public Map<String, Double> getRates() {
+        return rates;
+    }
+
+    public void setRates(Map<String, Double> rates) {
+        this.rates = rates;
+    }
+
+    public Double getUSD_BuySpread_IDR() {
+        return USD_BuySpread_IDR;
+    }
+
+    public void setUSD_BuySpread_IDR(Double USD_BuySpread_IDR) {
+        this.USD_BuySpread_IDR = USD_BuySpread_IDR;
+    }
+}

--- a/src/main/java/com/allobank/financeapi/model/enums/ResourceType.java
+++ b/src/main/java/com/allobank/financeapi/model/enums/ResourceType.java
@@ -1,0 +1,26 @@
+package com.allobank.financeapi.model.enums;
+
+public enum ResourceType {
+    LATEST_IDR_RATES("latest_idr_rates"),
+    HISTORICAL_IDR_USD("historical_idr_usd"),
+    SUPPORTED_CURRENCIES("supported_currencies");
+
+    private final String value;
+
+    ResourceType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ResourceType fromValue(String value) {
+        for (ResourceType type : values()) {
+            if (type.value.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid resource type: " + value);
+    }
+}

--- a/src/main/java/com/allobank/financeapi/runner/DataInitializer.java
+++ b/src/main/java/com/allobank/financeapi/runner/DataInitializer.java
@@ -1,0 +1,51 @@
+package com.allobank.financeapi.runner;
+
+import com.allobank.financeapi.model.enums.ResourceType;
+import com.allobank.financeapi.service.FinanceDataService;
+import com.allobank.financeapi.service.strategy.DataFetcherStrategy;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class DataInitializer implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DataInitializer.class);
+
+    private final FinanceDataService financeDataService;
+    private final List<DataFetcherStrategy> dataFetcherStrategies;
+
+    public DataInitializer(FinanceDataService financeDataService, List<DataFetcherStrategy> dataFetcherStrategies) {
+        this.financeDataService = financeDataService;
+        this.dataFetcherStrategies = dataFetcherStrategies;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Starting data initialization...");
+
+        Map<ResourceType, DataFetcherStrategy> strategyMap = this.dataFetcherStrategies.stream()
+                .filter(strategy -> strategy.getResourceType() != null)
+                .collect(Collectors.toMap(DataFetcherStrategy::getResourceType, Function.identity()));
+
+        Flux.fromIterable(strategyMap.entrySet())
+                .flatMap(entry -> entry.getValue().fetchData()
+                        .doOnNext(data -> this.financeDataService.storeData(entry.getKey(), data))
+                        .doOnError(error -> log.error("Error fetching data for resource {}: {}", entry.getKey(), error.getMessage()))
+                        .onErrorResume(error -> Mono.empty())) // Continue with other strategies if one fails
+                .doOnComplete(() -> {
+                    this.financeDataService.setImmutable();
+                    log.info("Data initialization completed.");
+                })
+                .subscribe();
+    }
+}

--- a/src/main/java/com/allobank/financeapi/service/FinanceDataService.java
+++ b/src/main/java/com/allobank/financeapi/service/FinanceDataService.java
@@ -1,0 +1,32 @@
+package com.allobank.financeapi.service;
+
+import com.allobank.financeapi.model.enums.ResourceType;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class FinanceDataService {
+
+    private Map<ResourceType, Object> dataStore = new ConcurrentHashMap<>();
+
+    public void storeData(ResourceType resourceType, Object data) {
+        this.dataStore.put(resourceType, data);
+    }
+
+    public Optional<Object> getData(ResourceType resourceType) {
+        return Optional.ofNullable(this.dataStore.get(resourceType));
+    }
+
+    public void setImmutable() {
+        this.dataStore = Collections.unmodifiableMap(new ConcurrentHashMap<>(this.dataStore));
+    }
+
+    // Added for testing purposes
+    public void clearData() {
+        this.dataStore = new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/com/allobank/financeapi/service/strategy/DataFetcherStrategy.java
+++ b/src/main/java/com/allobank/financeapi/service/strategy/DataFetcherStrategy.java
@@ -1,0 +1,9 @@
+package com.allobank.financeapi.service.strategy;
+
+import com.allobank.financeapi.model.enums.ResourceType;
+import reactor.core.publisher.Mono;
+
+public interface DataFetcherStrategy {
+    ResourceType getResourceType();
+    Mono<Object> fetchData();
+}

--- a/src/main/java/com/allobank/financeapi/service/strategy/HistoricalDataStrategy.java
+++ b/src/main/java/com/allobank/financeapi/service/strategy/HistoricalDataStrategy.java
@@ -1,0 +1,32 @@
+package com.allobank.financeapi.service.strategy;
+
+import com.allobank.financeapi.model.dto.HistoricalRatesResponse;
+import com.allobank.financeapi.model.enums.ResourceType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class HistoricalDataStrategy implements DataFetcherStrategy {
+
+    private final WebClient webClient;
+
+    public HistoricalDataStrategy(@Qualifier("frankfurterWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.HISTORICAL_IDR_USD;
+    }
+
+    @Override
+    public Mono<Object> fetchData() {
+        return this.webClient.get()
+                .uri("/2024-01-01..2024-01-05?from=IDR&to=USD")
+                .retrieve()
+                .bodyToMono(HistoricalRatesResponse.class)
+                .map(data -> (Object) data);
+    }
+}

--- a/src/main/java/com/allobank/financeapi/service/strategy/LatestRatesStrategy.java
+++ b/src/main/java/com/allobank/financeapi/service/strategy/LatestRatesStrategy.java
@@ -1,0 +1,43 @@
+package com.allobank.financeapi.service.strategy;
+
+import com.allobank.financeapi.model.dto.LatestRatesResponse;
+import com.allobank.financeapi.model.enums.ResourceType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class LatestRatesStrategy implements DataFetcherStrategy {
+
+    private final WebClient webClient;
+
+    public LatestRatesStrategy(@Qualifier("frankfurterWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    private static final double SPREAD_FACTOR = 0.00842; // (sum(ord(c) for c in "rakuszz0") % 1000) / 100000.0
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.LATEST_IDR_RATES;
+    }
+
+    @Override
+    public Mono<Object> fetchData() {
+        return this.webClient.get()
+                .uri("/latest?base=IDR")
+                .retrieve()
+                .bodyToMono(LatestRatesResponse.class)
+                .doOnNext(this::calculateSpread)
+                .map(data -> (Object) data);
+    }
+
+    private void calculateSpread(LatestRatesResponse response) {
+        if (response.getRates() != null && response.getRates().containsKey("USD")) {
+            double rateUsd = response.getRates().get("USD");
+            double spread = (1 / rateUsd) * (1 + SPREAD_FACTOR);
+            response.setUSD_BuySpread_IDR(spread);
+        }
+    }
+}

--- a/src/main/java/com/allobank/financeapi/service/strategy/SupportedCurrenciesStrategy.java
+++ b/src/main/java/com/allobank/financeapi/service/strategy/SupportedCurrenciesStrategy.java
@@ -1,0 +1,34 @@
+package com.allobank.financeapi.service.strategy;
+
+import com.allobank.financeapi.model.enums.ResourceType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Component
+public class SupportedCurrenciesStrategy implements DataFetcherStrategy {
+
+    private final WebClient webClient;
+
+    public SupportedCurrenciesStrategy(@Qualifier("frankfurterWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.SUPPORTED_CURRENCIES;
+    }
+
+    @Override
+    public Mono<Object> fetchData() {
+        return this.webClient.get()
+                .uri("/currencies")
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {})
+                .map(data -> (Object) data);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+api.frankfurter.baseUrl=https://api.frankfurter.app/

--- a/src/test/java/com/allobank/financeapi/runner/DataInitializerTest.java
+++ b/src/test/java/com/allobank/financeapi/runner/DataInitializerTest.java
@@ -1,0 +1,63 @@
+package com.allobank.financeapi.runner;
+
+import com.allobank.financeapi.FinanceApiApplication;
+import com.allobank.financeapi.model.enums.ResourceType;
+import com.allobank.financeapi.service.FinanceDataService;
+import com.allobank.financeapi.service.strategy.DataFetcherStrategy;
+import com.allobank.financeapi.service.strategy.HistoricalDataStrategy;
+import com.allobank.financeapi.service.strategy.LatestRatesStrategy;
+import com.allobank.financeapi.service.strategy.SupportedCurrenciesStrategy;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(classes = FinanceApiApplication.class)
+class DataInitializerTest {
+
+    @Autowired
+    private FinanceDataService financeDataService;
+
+    @MockBean
+    private LatestRatesStrategy latestRatesStrategy;
+
+    @MockBean
+    private HistoricalDataStrategy historicalDataStrategy;
+
+    @MockBean
+    private SupportedCurrenciesStrategy supportedCurrenciesStrategy;
+
+    @Autowired
+    private DataInitializer dataInitializer;
+
+    @Test
+    void run_initializesDataSuccessfully() throws Exception {
+        // Clear the data and reset immutability since it already ran during startup
+        financeDataService.clearData();
+
+        when(latestRatesStrategy.getResourceType()).thenReturn(ResourceType.LATEST_IDR_RATES);
+        when(latestRatesStrategy.fetchData()).thenReturn(Mono.just("latest_rates_data"));
+
+        when(historicalDataStrategy.getResourceType()).thenReturn(ResourceType.HISTORICAL_IDR_USD);
+        when(historicalDataStrategy.fetchData()).thenReturn(Mono.just("historical_data"));
+
+        when(supportedCurrenciesStrategy.getResourceType()).thenReturn(ResourceType.SUPPORTED_CURRENCIES);
+        when(supportedCurrenciesStrategy.fetchData()).thenReturn(Mono.just("supported_currencies_data"));
+
+        // Manually trigger the runner since it already ran during startup with unconfigured mocks
+        dataInitializer.run(null);
+
+        // Allow some time for the async operations to complete
+        Thread.sleep(1000);
+
+        assertTrue(financeDataService.getData(ResourceType.LATEST_IDR_RATES).isPresent());
+        assertTrue(financeDataService.getData(ResourceType.HISTORICAL_IDR_USD).isPresent());
+        assertTrue(financeDataService.getData(ResourceType.SUPPORTED_CURRENCIES).isPresent());
+    }
+}

--- a/src/test/java/com/allobank/financeapi/service/strategy/HistoricalDataStrategyTest.java
+++ b/src/test/java/com/allobank/financeapi/service/strategy/HistoricalDataStrategyTest.java
@@ -1,0 +1,54 @@
+package com.allobank.financeapi.service.strategy;
+
+import com.allobank.financeapi.model.dto.HistoricalRatesResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HistoricalDataStrategyTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @InjectMocks
+    private HistoricalDataStrategy historicalDataStrategy;
+
+    @BeforeEach
+    void setUp() {
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/2024-01-01..2024-01-05?from=IDR&to=USD")).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    @Test
+    void fetchData_returnsHistoricalData() {
+        HistoricalRatesResponse mockResponse = new HistoricalRatesResponse();
+        // Populate mockResponse with some data if needed
+
+        when(responseSpec.bodyToMono(HistoricalRatesResponse.class)).thenReturn(Mono.just(mockResponse));
+
+        Mono<Object> result = historicalDataStrategy.fetchData();
+
+        StepVerifier.create(result)
+                .expectNext(mockResponse)
+                .verifyComplete();
+    }
+}

--- a/src/test/java/com/allobank/financeapi/service/strategy/LatestRatesStrategyTest.java
+++ b/src/test/java/com/allobank/financeapi/service/strategy/LatestRatesStrategyTest.java
@@ -1,0 +1,62 @@
+package com.allobank.financeapi.service.strategy;
+
+import com.allobank.financeapi.model.dto.LatestRatesResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LatestRatesStrategyTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @InjectMocks
+    private LatestRatesStrategy latestRatesStrategy;
+
+    @BeforeEach
+    void setUp() {
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/latest?base=IDR")).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    @Test
+    void fetchData_calculatesSpreadCorrectly() {
+        LatestRatesResponse mockResponse = new LatestRatesResponse();
+        mockResponse.setRates(Map.of("USD", 0.000065));
+
+        when(responseSpec.bodyToMono(LatestRatesResponse.class)).thenReturn(Mono.just(mockResponse));
+
+        Mono<Object> result = latestRatesStrategy.fetchData();
+
+        StepVerifier.create(result)
+                .expectNextMatches(responseObject -> {
+                    LatestRatesResponse response = (LatestRatesResponse) responseObject;
+                    double expectedSpread = (1 / 0.000065) * (1 + 0.00842);
+                    return response.getUSD_BuySpread_IDR() != null &&
+                           Math.abs(response.getUSD_BuySpread_IDR() - expectedSpread) < 0.0001;
+                })
+                .verifyComplete();
+    }
+}

--- a/src/test/java/com/allobank/financeapi/service/strategy/SupportedCurrenciesStrategyTest.java
+++ b/src/test/java/com/allobank/financeapi/service/strategy/SupportedCurrenciesStrategyTest.java
@@ -1,0 +1,55 @@
+package com.allobank.financeapi.service.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SupportedCurrenciesStrategyTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @InjectMocks
+    private SupportedCurrenciesStrategy supportedCurrenciesStrategy;
+
+    @BeforeEach
+    void setUp() {
+        when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        when(requestHeadersUriSpec.uri("/currencies")).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    @Test
+    void fetchData_returnsSupportedCurrencies() {
+        Map<String, String> mockResponse = Map.of("USD", "United States Dollar", "EUR", "Euro");
+
+        when(responseSpec.bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {})).thenReturn(Mono.just(mockResponse));
+
+        Mono<Object> result = supportedCurrenciesStrategy.fetchData();
+
+        StepVerifier.create(result)
+                .expectNext(mockResponse)
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
Architectural Rationale

### Polymorphism Justification: The Strategy Pattern

The Strategy Pattern was chosen to handle the different data resources (`latest_idr_rates`, `historical_idr_usd`, `supported_currencies`) for several key reasons:

*   **Extensibility**: Adding a new data resource is as simple as creating a new class that implements the `DataFetcherStrategy` interface. The core logic of the application does not need to be modified. This adheres to the Open/Closed Principle.
*   **Maintainability**: Each strategy is self-contained and responsible for a single piece of functionality. This makes the code easier to read, understand, and test.
*   **Decoupling**: The `FinanceController` is completely decoupled from the implementation details of how the data is fetched. It simply delegates the task to the appropriate strategy, which is resolved at runtime by Spring's dependency injection mechanism. This avoids a chain of `if/else` or `switch` statements, which would become unwieldy as more resources are added.

### Client Factory: The `FactoryBean`

A `FactoryBean` was used to create the `WebClient` instance for the following reasons:

*   **Encapsulation of Complex Initialization**: The `FactoryBean` encapsulates the logic for creating and configuring the `WebClient`. This is particularly useful if the client requires more complex setup, such as setting default headers, timeouts, or filters. By centralizing this logic, we avoid cluttering our `@Configuration` classes.
*   **Separation of Concerns**: The `FactoryBean`'s sole responsibility is to create the `WebClient`. This is a cleaner approach than defining a `@Bean` method directly in a configuration class, especially when the creation logic is non-trivial.
*   **Lazy Initialization**: While not explicitly configured here, a `FactoryBean` can provide more control over the bean's lifecycle, including lazy initialization.

### Startup Runner Choice: `ApplicationRunner`

An `ApplicationRunner` was used for the initial data ingestion for these reasons:

*   **Guaranteed Execution Order**: `ApplicationRunner` (and `CommandLineRunner`) beans are executed after the application context has been fully initialized but before the application is ready to accept requests. This ensures that the in-memory data store is populated before any client can access the API.
*   **Separation from Bean Lifecycle**: Using `@PostConstruct` on a service method would tie the data loading logic to the lifecycle of that specific bean. An `ApplicationRunner` is a more explicit and dedicated component for startup tasks, making the application's bootstrap process clearer.
*   **Access to Application Arguments**: `ApplicationRunner` provides access to command-line arguments, which can be useful for more advanced configuration scenarios.