### PR TITLE
Feat/idr rate aggregator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.13</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.allobank</groupId>
+	<artifactId>idr-rates</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name/>
+	<description/>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>4.12.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/allobank/idrrates/IdrRatesApplication.java
+++ b/src/main/java/com/allobank/idrrates/IdrRatesApplication.java
@@ -1,0 +1,13 @@
+package com.allobank.idrrates;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class IdrRatesApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(IdrRatesApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/allobank/idrrates/IdrRatesApplication.java
+++ b/src/main/java/com/allobank/idrrates/IdrRatesApplication.java
@@ -1,13 +1,19 @@
 package com.allobank.idrrates;
 
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class IdrRatesApplication {
 
+	private static final Logger log = LoggerFactory.getLogger(IdrRatesApplication.class);
+
 	public static void main(String[] args) {
 		SpringApplication.run(IdrRatesApplication.class, args);
+		log.info("Spring boot application started");
 	}
 
 }

--- a/src/main/java/com/allobank/idrrates/README.md
+++ b/src/main/java/com/allobank/idrrates/README.md
@@ -1,0 +1,47 @@
+# IDR Rate Aggregator
+
+A Spring Boot REST API that fetches and serves IDR exchange rate data from the [Frankfurter API](https://api.frankfurter.dev).
+
+## Setup & Run
+
+### Prerequisites
+- Java 21+
+- Maven
+
+### Run the application
+```bash
+./mvnw spring-boot:run
+```
+
+### Run tests
+```bash
+./mvnw test
+```
+
+## Endpoint Usage
+
+Base URL: `http://localhost:8080`
+```bash
+# Latest IDR rates
+curl http://localhost:8080/api/finance/data/latest_idr_rates
+
+# Historical IDR/USD rates
+curl http://localhost:8080/api/finance/data/historical_idr_usd
+
+# Supported currencies
+curl http://localhost:8080/api/finance/data/supported_currencies
+```
+
+## Personalization Note
+
+**GitHub Username:** `FarizMR`  
+**Spread Factor:** `(763 % 1000) / 100_000.0` = **0.00763**  
+**Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + 0.00763)`
+
+## Architectural Rationale
+
+**1. Strategy Pattern** : Each resource type is handled by its own class. Adding a new resource only needs a new class, no changes to existing code. The controller picks the right handler from a map, no if/else needed.
+
+**2. FactoryBean** : Keeps all WebClient setup (base URL, timeout) in one dedicated class instead of scattered across config.
+
+**3. ApplicationRunner** : Runs after everything is ready, so all beans are available when data fetching starts.

--- a/src/main/java/com/allobank/idrrates/config/DataInitializer.java
+++ b/src/main/java/com/allobank/idrrates/config/DataInitializer.java
@@ -28,9 +28,13 @@ public class DataInitializer implements ApplicationRunner {
     public void run(ApplicationArguments args) throws Exception {
         log.info("Starting data initialization...");
         for (IdrDataFetcher fetcher : fetchers) {
-            log.info("Fetching data for resource type: {}", fetcher.getResourceType());
-            Object data = fetcher.fetchData();
-            dataStore.put(fetcher.getResourceType(), data);
+            try {
+                log.info("Fetching data for resource type: {}", fetcher.getResourceType());
+                Object data = fetcher.fetchData();
+                dataStore.put(fetcher.getResourceType(), data);
+            } catch (Exception e) {
+                log.error("Failed to fetch data for resource type: {} - {}", fetcher.getResourceType(), e.getMessage());
+            }
         }
         dataStore.markInitialized();
         log.info("Data initialization complete");

--- a/src/main/java/com/allobank/idrrates/config/DataInitializer.java
+++ b/src/main/java/com/allobank/idrrates/config/DataInitializer.java
@@ -1,0 +1,38 @@
+package com.allobank.idrrates.config;
+
+import com.allobank.idrrates.store.DataStore;
+import com.allobank.idrrates.strategy.IdrDataFetcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class DataInitializer implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DataInitializer.class);
+
+    @Autowired
+    private DataStore dataStore;
+    private final List<IdrDataFetcher> fetchers;
+
+    public DataInitializer(List<IdrDataFetcher> fetchers) {
+        this.fetchers = fetchers;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("Starting data initialization...");
+        for (IdrDataFetcher fetcher : fetchers) {
+            log.info("Fetching data for resource type: {}", fetcher.getResourceType());
+            Object data = fetcher.fetchData();
+            dataStore.put(fetcher.getResourceType(), data);
+        }
+        dataStore.markInitialized();
+        log.info("Data initialization complete");
+    }
+}

--- a/src/main/java/com/allobank/idrrates/config/WebClientFactoryBean.java
+++ b/src/main/java/com/allobank/idrrates/config/WebClientFactoryBean.java
@@ -1,0 +1,48 @@
+package com.allobank.idrrates.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Component
+public class WebClientFactoryBean implements FactoryBean<WebClient> {
+
+    private static final Logger log = LoggerFactory.getLogger(WebClientFactoryBean.class);
+
+    @Value("${frankfurter.baseurl}")
+    private String baseUrl;
+
+    @Value("${frankfurter.timeout}")
+    private int timeoutSeconds;
+
+    @Override
+    public WebClient getObject() {
+        HttpClient httpClient = HttpClient.create()
+                .responseTimeout(Duration.ofSeconds(timeoutSeconds));
+        log.info("Initializing webcllient with base URL : {} and timeout {}s", baseUrl, timeoutSeconds);
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(clientCodecConfigurer -> clientCodecConfigurer
+                        .defaultCodecs()
+                        .maxInMemorySize(1024 * 1024))
+                .build();
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return WebClient.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+}

--- a/src/main/java/com/allobank/idrrates/controller/FinanceController.java
+++ b/src/main/java/com/allobank/idrrates/controller/FinanceController.java
@@ -1,0 +1,32 @@
+package com.allobank.idrrates.controller;
+
+import com.allobank.idrrates.store.DataStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/finance")
+public class FinanceController {
+
+    private static final Logger log = LoggerFactory.getLogger(FinanceController.class);
+
+    @Autowired
+    private DataStore dataStore;
+
+    @GetMapping("/data/{resourceType}")
+    public ResponseEntity<Object> getData(@PathVariable String resourceType) {
+        log.info("Received request for resource type: {}", resourceType);
+        Object data = dataStore.get(resourceType);
+        if (data == null) {
+            log.warn("Resource type not found: {}", resourceType);
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(data);
+    }
+}

--- a/src/main/java/com/allobank/idrrates/controller/FinanceController.java
+++ b/src/main/java/com/allobank/idrrates/controller/FinanceController.java
@@ -4,11 +4,14 @@ import com.allobank.idrrates.store.DataStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/finance")
@@ -25,7 +28,8 @@ public class FinanceController {
         Object data = dataStore.get(resourceType);
         if (data == null) {
             log.warn("Resource type not found: {}", resourceType);
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "Resource type not found: " + resourceType));
         }
         return ResponseEntity.ok(data);
     }

--- a/src/main/java/com/allobank/idrrates/dto/CurrenciesDTO.java
+++ b/src/main/java/com/allobank/idrrates/dto/CurrenciesDTO.java
@@ -1,14 +1,27 @@
 package com.allobank.idrrates.dto;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class CurrenciesDTO {
-    private Map<String, String> currencies;
+    private Map<String, String> currencies = new HashMap<>();
+
+    @JsonAnySetter
+    public void setCurrency(String key, String value) {
+        currencies.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, String> getCurrencies() {
+        return currencies;
+    }
 }

--- a/src/main/java/com/allobank/idrrates/dto/CurrenciesDTO.java
+++ b/src/main/java/com/allobank/idrrates/dto/CurrenciesDTO.java
@@ -1,0 +1,14 @@
+package com.allobank.idrrates.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CurrenciesDTO {
+    private Map<String, String> currencies;
+}

--- a/src/main/java/com/allobank/idrrates/dto/LatestRatesDTO.java
+++ b/src/main/java/com/allobank/idrrates/dto/LatestRatesDTO.java
@@ -1,5 +1,6 @@
 package com.allobank.idrrates.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,4 +15,7 @@ public class LatestRatesDTO {
     private String base;
     private String date;
     private Map<String, Double> rates;
+
+    @JsonProperty("USD_BuySpread_IDR")
+    private Double usdBuySpreadIdr;
 }

--- a/src/main/java/com/allobank/idrrates/dto/LatestRatesDTO.java
+++ b/src/main/java/com/allobank/idrrates/dto/LatestRatesDTO.java
@@ -1,0 +1,17 @@
+package com.allobank.idrrates.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LatestRatesDTO {
+    private Double amount;
+    private String base;
+    private String date;
+    private Map<String, Double> rates;
+}

--- a/src/main/java/com/allobank/idrrates/dto/TimeseriesRatesDTO.java
+++ b/src/main/java/com/allobank/idrrates/dto/TimeseriesRatesDTO.java
@@ -1,0 +1,24 @@
+package com.allobank.idrrates.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeseriesRatesDTO {
+    private Double amount;
+    private String base;
+
+    @JsonProperty("start_date")
+    private String startDate;
+
+    @JsonProperty("end_date")
+    private String endDate;
+
+    private Map<String, Map<String, Double>> rates;
+}

--- a/src/main/java/com/allobank/idrrates/store/DataStore.java
+++ b/src/main/java/com/allobank/idrrates/store/DataStore.java
@@ -1,0 +1,38 @@
+package com.allobank.idrrates.store;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class DataStore {
+
+    private static final Logger log = LoggerFactory.getLogger(DataStore.class);
+    private final Map<String, Object> store = new ConcurrentHashMap<>();
+    private volatile boolean initialized = false;
+
+    public void put(String resourceType, Object data) {
+        if (initialized) {
+            throw new IllegalStateException("Data store is already initialized and is immutable");
+        }
+        log.info("Storing data for resource type: {}", resourceType);
+        store.put(resourceType, data);
+    }
+
+    public void markInitialized() {
+        this.initialized = true;
+        log.info("FinanceDataStore initialized with {} resources", store.size());
+    }
+
+    public Object get(String resourceType) {
+        return store.get(resourceType);
+    }
+
+    public Map<String, Object> getAll() {
+        return Collections.unmodifiableMap(store);
+    }
+}

--- a/src/main/java/com/allobank/idrrates/strategy/CurrenciesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/CurrenciesStrategy.java
@@ -1,0 +1,33 @@
+package com.allobank.idrrates.strategy;
+
+import com.allobank.idrrates.dto.CurrenciesDTO;
+import com.allobank.idrrates.dto.TimeseriesRatesDTO;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class CurrenciesStrategy implements IdrDataFetcher {
+
+    private static final Logger log = LoggerFactory.getLogger(CurrenciesStrategy.class);
+    @Autowired
+    private WebClient webClient;
+
+    @Override
+    public String getResourceType() {
+        return "supported_currencies";
+    }
+
+    @Override
+    public Object fetchData() {
+        log.info("Fetching supported currencies from Frankfurter API");
+        return webClient.get()
+                .uri("/currencies")
+                .retrieve()
+                .bodyToMono(CurrenciesDTO.class)
+                .block();
+    }
+}

--- a/src/main/java/com/allobank/idrrates/strategy/CurrenciesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/CurrenciesStrategy.java
@@ -13,8 +13,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class CurrenciesStrategy implements IdrDataFetcher {
 
     private static final Logger log = LoggerFactory.getLogger(CurrenciesStrategy.class);
+
     @Autowired
-    private WebClient webClient;
+    public WebClient webClient;
 
     @Override
     public String getResourceType() {

--- a/src/main/java/com/allobank/idrrates/strategy/CurrenciesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/CurrenciesStrategy.java
@@ -27,7 +27,14 @@ public class CurrenciesStrategy implements IdrDataFetcher {
         return webClient.get()
                 .uri("/currencies")
                 .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .map(body -> new RuntimeException(
+                                        "External API error:" + clientResponse.statusCode() + " - " + body
+                                )))
                 .bodyToMono(CurrenciesDTO.class)
+                .onErrorMap(Exception.class,
+                        ex -> new RuntimeException("Failed to fetch latest IDR rates", ex))
                 .block();
     }
 }

--- a/src/main/java/com/allobank/idrrates/strategy/IdrDataFetcher.java
+++ b/src/main/java/com/allobank/idrrates/strategy/IdrDataFetcher.java
@@ -1,0 +1,6 @@
+package com.allobank.idrrates.strategy;
+
+public interface IdrDataFetcher {
+    String getResourceType();
+    Object fetchData();
+}

--- a/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
@@ -13,7 +13,7 @@ public class LatestRatesStrategy implements IdrDataFetcher {
 
     private static final Logger log = LoggerFactory.getLogger(LatestRatesStrategy.class);
     @Autowired
-    private WebClient webClient;
+    public WebClient webClient;
 
     @Override
     public String getResourceType() {

--- a/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
@@ -1,0 +1,33 @@
+package com.allobank.idrrates.strategy;
+
+import com.allobank.idrrates.dto.LatestRatesDTO;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class LatestRatesStrategy implements IdrDataFetcher {
+
+    private static final Logger log = LoggerFactory.getLogger(LatestRatesStrategy.class);
+    @Autowired
+    private WebClient webClient;
+
+    @Override
+    public String getResourceType() {
+        return "latest_idr_rates";
+
+    }
+
+    @Override
+    public Object fetchData() {
+        log.info("Fetching latest IDR rates from Frankfurter API");
+        return webClient.get()
+                .uri("/rates/latest?base=IDR")
+                .retrieve()
+                .bodyToMono(LatestRatesDTO.class)
+                .block();
+    }
+}

--- a/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
@@ -25,7 +25,7 @@ public class LatestRatesStrategy implements IdrDataFetcher {
     public Object fetchData() {
         log.info("Fetching latest IDR rates from Frankfurter API");
         return webClient.get()
-                .uri("/rates/latest?base=IDR")
+                .uri("/latest?base=IDR")
                 .retrieve()
                 .bodyToMono(LatestRatesDTO.class)
                 .block();

--- a/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
@@ -24,7 +24,7 @@ public class LatestRatesStrategy implements IdrDataFetcher {
     @Override
     public Object fetchData() {
         log.info("Fetching latest IDR rates from Frankfurter API");
-        return webClient.get()
+        LatestRatesDTO dto = webClient.get()
                 .uri("/latest?base=IDR")
                 .retrieve()
                 .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
@@ -36,5 +36,24 @@ public class LatestRatesStrategy implements IdrDataFetcher {
                 .onErrorMap(Exception.class,
                         ex -> new RuntimeException("Failed to fetch latest IDR rates", ex))
                 .block();
+
+        if (dto != null && dto.getRates() != null) {
+            Double rateUsd = dto.getRates().get("USD");
+            if (rateUsd != null && rateUsd != 0) {
+                double spreadFactor = calculateSpreadFactor("farizmr");
+                double usdBuySpreadIdr = (1.0 / rateUsd) * (1.0 + spreadFactor);
+                dto.setUsdBuySpreadIdr(usdBuySpreadIdr);
+                log.info("USD_BuySpread_IDR calculated: {}", usdBuySpreadIdr);
+            }
+        }
+
+        return dto;
+    }
+
+    private double calculateSpreadFactor(String githubUsername) {
+        int sum = githubUsername.toLowerCase()
+                .chars()
+                .sum();
+        return (sum % 1000) / 100_000.0;
     }
 }

--- a/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/LatestRatesStrategy.java
@@ -27,7 +27,14 @@ public class LatestRatesStrategy implements IdrDataFetcher {
         return webClient.get()
                 .uri("/latest?base=IDR")
                 .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .map(body -> new RuntimeException(
+                                        "External API error:" + clientResponse.statusCode() + " - " + body
+                                )))
                 .bodyToMono(LatestRatesDTO.class)
+                .onErrorMap(Exception.class,
+                        ex -> new RuntimeException("Failed to fetch latest IDR rates", ex))
                 .block();
     }
 }

--- a/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
@@ -1,0 +1,32 @@
+package com.allobank.idrrates.strategy;
+
+import com.allobank.idrrates.dto.TimeseriesRatesDTO;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class TimeseriesRatesStrategy implements IdrDataFetcher {
+
+    private static final Logger log = LoggerFactory.getLogger(TimeseriesRatesStrategy.class);
+    @Autowired
+    private WebClient webClient;
+
+    @Override
+    public String getResourceType() {
+        return "historical_idr_usd";
+    }
+
+    @Override
+    public Object fetchData() {
+        log.info("Fetching historical IDR/USD rates from Frankfurter API");
+        return webClient.get()
+                .uri("/rates/2026-01-01..2026-02-01?from=IDR&to=USD")
+                .retrieve()
+                .bodyToMono(TimeseriesRatesDTO.class)
+                .block();
+    }
+}

--- a/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
@@ -12,8 +12,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class TimeseriesRatesStrategy implements IdrDataFetcher {
 
     private static final Logger log = LoggerFactory.getLogger(TimeseriesRatesStrategy.class);
+
     @Autowired
-    private WebClient webClient;
+    public WebClient webClient;
 
     @Override
     public String getResourceType() {

--- a/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
@@ -26,7 +26,14 @@ public class TimeseriesRatesStrategy implements IdrDataFetcher {
         return webClient.get()
                 .uri("/2026-01-01..2026-02-01?from=IDR&to=USD")
                 .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .map(body -> new RuntimeException(
+                                        "External API error:" + clientResponse.statusCode() + " - " + body
+                                )))
                 .bodyToMono(TimeseriesRatesDTO.class)
+                .onErrorMap(Exception.class,
+                        ex -> new RuntimeException("Failed to fetch latest IDR rates", ex))
                 .block();
     }
 }

--- a/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
+++ b/src/main/java/com/allobank/idrrates/strategy/TimeseriesRatesStrategy.java
@@ -24,7 +24,7 @@ public class TimeseriesRatesStrategy implements IdrDataFetcher {
     public Object fetchData() {
         log.info("Fetching historical IDR/USD rates from Frankfurter API");
         return webClient.get()
-                .uri("/rates/2026-01-01..2026-02-01?from=IDR&to=USD")
+                .uri("/2026-01-01..2026-02-01?from=IDR&to=USD")
                 .retrieve()
                 .bodyToMono(TimeseriesRatesDTO.class)
                 .block();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
 spring:
   application:
     name: idr-rates
+
+frankfurter:
+  baseurl: https://api.frankfurter.app
+  timeout: 10 #In seconds

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,5 +3,5 @@ spring:
     name: idr-rates
 
 frankfurter:
-  baseurl: https://api.frankfurter.app
+  baseurl: https://api.frankfurter.dev/v1
   timeout: 10 #In seconds

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: idr-rates

--- a/src/test/java/com/allobank/idrrates/CurrenciesStrategyTest.java
+++ b/src/test/java/com/allobank/idrrates/CurrenciesStrategyTest.java
@@ -1,0 +1,65 @@
+package com.allobank.idrrates;
+
+import com.allobank.idrrates.dto.CurrenciesDTO;
+import com.allobank.idrrates.dto.TimeseriesRatesDTO;
+import com.allobank.idrrates.strategy.CurrenciesStrategy;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CurrenciesStrategyTest {
+
+    private MockWebServer mockWebServer;
+    private CurrenciesStrategy strategy;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        strategy = new CurrenciesStrategy();
+        strategy.webClient = webClient;
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void getResourceType_shouldReturnSupportedCurrencies() {
+        assertThat(strategy.getResourceType()).isEqualTo("supported_currencies");
+    }
+
+    @Test
+    void fetchData_shouldReturnCurrenciesMap() {
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("""
+                        {
+                            "AUD": "Australian Dollar",
+                            "USD": "United States Dollar",
+                            "IDR": "Indonesian Rupiah"
+                        }
+                        """)
+                .addHeader("Content-Type", "application/json"));
+
+        CurrenciesDTO result = (CurrenciesDTO) strategy.fetchData();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCurrencies()).containsKey("AUD");
+        assertThat(result.getCurrencies()).containsKey("USD");
+        assertThat(result.getCurrencies()).containsKey("IDR");
+        assertThat(result.getCurrencies().get("IDR")).isEqualTo("Indonesian Rupiah");
+    }
+}

--- a/src/test/java/com/allobank/idrrates/IdrRatesApplicationTests.java
+++ b/src/test/java/com/allobank/idrrates/IdrRatesApplicationTests.java
@@ -1,0 +1,13 @@
+package com.allobank.idrrates;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class IdrRatesApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/allobank/idrrates/IdrRatesApplicationTests.java
+++ b/src/test/java/com/allobank/idrrates/IdrRatesApplicationTests.java
@@ -1,13 +1,25 @@
 package com.allobank.idrrates;
 
+import com.allobank.idrrates.store.DataStore;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class IdrRatesApplicationTests {
+
+	@Autowired
+	private DataStore dataStore;
 
 	@Test
 	void contextLoads() {
 	}
 
+	@Test
+	void dataStore_shouldBeInitializedWithAllThreeResources() {
+		assertThat(dataStore.get("latest_idr_rates")).isNotNull();
+		assertThat(dataStore.get("historical_idr_usd")).isNotNull();
+		assertThat(dataStore.get("supported_currencies")).isNotNull();
+	}
 }

--- a/src/test/java/com/allobank/idrrates/LatestRatesStrategyTest.java
+++ b/src/test/java/com/allobank/idrrates/LatestRatesStrategyTest.java
@@ -1,0 +1,65 @@
+package com.allobank.idrrates;
+
+import com.allobank.idrrates.dto.LatestRatesDTO;
+import com.allobank.idrrates.strategy.LatestRatesStrategy;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LatestRatesStrategyTest {
+
+    private MockWebServer mockWebServer;
+    private LatestRatesStrategy strategy;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        strategy = new LatestRatesStrategy();
+        strategy.webClient = webClient;
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void getResourceType_shouldReturnLatestIdrRates() {
+        assertThat(strategy.getResourceType()).isEqualTo("latest_idr_rates");
+    }
+
+    @Test
+    void fetchData_shouldReturnLatestRatesWithSpread() {
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("""
+                        {
+                            "amount": 1.0,
+                            "base": "IDR",
+                            "date": "2026-03-30",
+                            "rates": { "USD": 0.000059 }
+                        }
+                        """)
+                .addHeader("Content-Type", "application/json"));
+
+        LatestRatesDTO result = (LatestRatesDTO) strategy.fetchData();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getBase()).isEqualTo("IDR");
+        assertThat(result.getRates()).containsKey("USD");
+        assertThat(result.getUsdBuySpreadIdr()).isNotNull();
+        assertThat(result.getUsdBuySpreadIdr()).isGreaterThan(0);
+    }
+}

--- a/src/test/java/com/allobank/idrrates/TimeseriesRatesStrategyTest.java
+++ b/src/test/java/com/allobank/idrrates/TimeseriesRatesStrategyTest.java
@@ -1,0 +1,83 @@
+package com.allobank.idrrates;
+
+import com.allobank.idrrates.dto.LatestRatesDTO;
+import com.allobank.idrrates.strategy.LatestRatesStrategy;
+import com.allobank.idrrates.strategy.TimeseriesRatesStrategy;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.allobank.idrrates.dto.TimeseriesRatesDTO;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimeseriesRatesStrategyTest {
+
+    private MockWebServer mockWebServer;
+    private TimeseriesRatesStrategy strategy;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(mockWebServer.url("/").toString())
+                .build();
+
+        strategy = new TimeseriesRatesStrategy();
+        strategy.webClient = webClient;
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void getResourceType_shouldReturnHistoricalIdrUsd() {
+        assertThat(strategy.getResourceType()).isEqualTo("historical_idr_usd");
+    }
+
+    @Test
+    void fetchData_shouldReturnTimeseriesRatesWithDates() {
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("""
+                        {
+                            "amount": 1.0,
+                            "base": "IDR",
+                            "start_date": "2025-12-31",
+                            "end_date": "2026-01-30",
+                            "rates": {
+                                "2025-12-31": { "USD": 0.000060 },
+                                "2026-01-02": { "USD": 0.000060 }
+                            }
+                        }
+                        """)
+                .addHeader("Content-Type", "application/json"));
+
+        TimeseriesRatesDTO result = (TimeseriesRatesDTO) strategy.fetchData();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getBase()).isEqualTo("IDR");
+        assertThat(result.getStartDate()).isEqualTo("2025-12-31");
+        assertThat(result.getEndDate()).isEqualTo("2026-01-30");
+        assertThat(result.getRates()).containsKey("2025-12-31");
+        assertThat(result.getRates()).containsKey("2026-01-02");
+    }
+}


### PR DESCRIPTION
# IDR Rate Aggregator

A Spring Boot REST API that fetches and serves IDR exchange rate data from the [Frankfurter API](https://api.frankfurter.dev).

## Setup & Run

### Prerequisites
- Java 21+
- Maven

### Run the application
```bash
./mvnw spring-boot:run
```

### Run tests
```bash
./mvnw test
```

## Endpoint Usage

Base URL: `http://localhost:8080`
```bash
# Latest IDR rates
curl http://localhost:8080/api/finance/data/latest_idr_rates

# Historical IDR/USD rates
curl http://localhost:8080/api/finance/data/historical_idr_usd

# Supported currencies
curl http://localhost:8080/api/finance/data/supported_currencies
```

## Personalization Note

**GitHub Username:** `FarizMR`  
**Spread Factor:** `(763 % 1000) / 100_000.0` = **0.00763**  
**Formula:** `USD_BuySpread_IDR = (1 / Rate_USD) * (1 + 0.00763)`

## Architectural Rationale

**1. Strategy Pattern** : Each resource type is handled by its own class. Adding a new resource only needs a new class, no changes to existing code. The controller picks the right handler from a map, no if/else needed.

**2. FactoryBean** : Keeps all WebClient setup (base URL, timeout) in one dedicated class instead of scattered across config.

**3. ApplicationRunner** : Runs after everything is ready, so all beans are available when data fetching starts.